### PR TITLE
Introduce HttpSend trait for converting `Request` -> `Response`

### DIFF
--- a/examples/register.rs
+++ b/examples/register.rs
@@ -6,9 +6,9 @@ use std::{error::Error, io};
 
 use self::elefren::{
     apps::{App, Scopes},
+    data::toml,
     Mastodon,
     Registration,
-    data::toml,
 };
 
 #[allow(dead_code)]

--- a/src/entities/itemsiter.rs
+++ b/src/entities/itemsiter.rs
@@ -1,4 +1,5 @@
 use page::Page;
+use http_send::HttpSend;
 use serde::Deserialize;
 
 /// Abstracts away the `next_page` logic into a single stream of items
@@ -23,15 +24,15 @@ use serde::Deserialize;
 /// # Ok(())
 /// # }
 /// ```
-pub(crate) struct ItemsIter<'a, T: Clone + for<'de> Deserialize<'de>> {
-    page: Page<'a, T>,
+pub(crate) struct ItemsIter<'a, T: Clone + for<'de> Deserialize<'de>, H: 'a + HttpSend> {
+    page: Page<'a, T, H>,
     buffer: Vec<T>,
     cur_idx: usize,
     use_initial: bool,
 }
 
-impl<'a, T: Clone + for<'de> Deserialize<'de>> ItemsIter<'a, T> {
-    pub(crate) fn new(page: Page<'a, T>) -> ItemsIter<'a, T> {
+impl<'a, T: Clone + for<'de> Deserialize<'de>, H: HttpSend> ItemsIter<'a, T, H> {
+    pub(crate) fn new(page: Page<'a, T, H>) -> ItemsIter<'a, T, H> {
         ItemsIter {
             page,
             buffer: vec![],
@@ -60,7 +61,7 @@ impl<'a, T: Clone + for<'de> Deserialize<'de>> ItemsIter<'a, T> {
     }
 }
 
-impl<'a, T: Clone + for<'de> Deserialize<'de>> Iterator for ItemsIter<'a, T> {
+impl<'a, T: Clone + for<'de> Deserialize<'de>, H: HttpSend> Iterator for ItemsIter<'a, T, H> {
     type Item = T;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/src/entities/itemsiter.rs
+++ b/src/entities/itemsiter.rs
@@ -1,5 +1,5 @@
-use page::Page;
 use http_send::HttpSend;
+use page::Page;
 use serde::Deserialize;
 
 /// Abstracts away the `next_page` logic into a single stream of items

--- a/src/http_send.rs
+++ b/src/http_send.rs
@@ -1,5 +1,5 @@
-use Result;
 use reqwest::{Client, Request, RequestBuilder, Response};
+use Result;
 
 pub trait HttpSend {
     fn execute(&self, client: &Client, request: Request) -> Result<Response>;

--- a/src/http_send.rs
+++ b/src/http_send.rs
@@ -1,0 +1,18 @@
+use Result;
+use reqwest::{Client, Request, RequestBuilder, Response};
+
+pub trait HttpSend {
+    fn execute(&self, client: &Client, request: Request) -> Result<Response>;
+    fn send(&self, client: &Client, builder: &mut RequestBuilder) -> Result<Response> {
+        let request = builder.build()?;
+        self.execute(client, request)
+    }
+}
+
+pub struct HttpSender;
+
+impl HttpSend for HttpSender {
+    fn execute(&self, client: &Client, request: Request) -> Result<Response> {
+        Ok(client.execute(request)?)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,13 +49,13 @@ use std::{borrow::Cow, ops};
 use reqwest::{
     header::{Authorization, Bearer, Headers},
     Client,
-    Response,
     RequestBuilder,
+    Response,
 };
 
 use entities::prelude::*;
-use page::Page;
 use http_send::{HttpSend, HttpSender};
+use page::Page;
 
 pub use data::Data;
 pub use errors::{ApiError, Error, Result};
@@ -265,10 +265,9 @@ impl<H: HttpSend> Mastodon<H> {
     }
 
     pub(crate) fn send(&self, req: &mut RequestBuilder) -> Result<Response> {
-        Ok(self.http_sender.send(
-                &self.client,
-                req.headers(self.headers.clone())
-        )?)
+        Ok(self
+            .http_sender
+            .send(&self.client, req.headers(self.headers.clone()))?)
     }
 }
 
@@ -338,11 +337,7 @@ impl<H: HttpSend> MastodonClient<H> for Mastodon<H> {
 
     fn update_credentials(&self, changes: CredientialsBuilder) -> Result<Account> {
         let url = self.route("/api/v1/accounts/update_credentials");
-        let response = self.send(
-                self.client
-                    .patch(&url)
-                    .multipart(changes.into_form()?)
-        )?;
+        let response = self.send(self.client.patch(&url).multipart(changes.into_form()?))?;
 
         let status = response.status().clone();
 
@@ -360,7 +355,7 @@ impl<H: HttpSend> MastodonClient<H> for Mastodon<H> {
         let response = self.send(
             self.client
                 .post(&self.route("/api/v1/statuses"))
-                .json(&status)
+                .json(&status),
         )?;
 
         deserialise(response)
@@ -441,9 +436,7 @@ impl<H: HttpSend> MastodonClient<H> for Mastodon<H> {
             url = format!("{}{}", url, request.to_querystring());
         }
 
-        let response = self.send(
-                &mut self.client.get(&url)
-        )?;
+        let response = self.send(&mut self.client.get(&url))?;
 
         Page::new(self, response)
     }
@@ -465,9 +458,7 @@ impl<H: HttpSend> MastodonClient<H> for Mastodon<H> {
             url.pop();
         }
 
-        let response = self.send(
-                &mut self.client.get(&url)
-        )?;
+        let response = self.send(&mut self.client.get(&url))?;
 
         Page::new(self, response)
     }
@@ -489,9 +480,7 @@ impl<H: HttpSend> MastodonClient<H> for Mastodon<H> {
             following
         );
 
-        let response = self.send(
-                &mut self.client.get(&url)
-        )?;
+        let response = self.send(&mut self.client.get(&url))?;
 
         Page::new(self, response)
     }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -4,9 +4,9 @@ macro_rules! methods {
             fn $method<T: for<'de> serde::Deserialize<'de>>(&self, url: String)
             -> Result<T>
             {
-                let response = self.client.$method(&url)
-                    .headers(self.headers.clone())
-                    .send()?;
+                let response = self.send(
+                        &mut self.client.$method(&url)
+                )?;
 
                 deserialise(response)
             }
@@ -22,11 +22,11 @@ macro_rules! paged_routes {
                 "Equivalent to `/api/v1/",
                 $url,
                 "`\n# Errors\nIf `access_token` is not set."),
-            fn $name(&self) -> Result<Page<$ret>> {
+            fn $name(&self) -> Result<Page<$ret, H>> {
                 let url = self.route(concat!("/api/v1/", $url));
-                let response = self.client.$method(&url)
-                    .headers(self.headers.clone())
-                    .send()?;
+                let response = self.send(
+                        &mut self.client.$method(&url)
+                )?;
 
                 Page::new(self, response)
             }
@@ -55,10 +55,11 @@ macro_rules! route {
                         .file(stringify!($param), $param.as_ref())?
                      )*;
 
-                let response = self.client.post(&self.route(concat!("/api/v1/", $url)))
-                    .headers(self.headers.clone())
-                    .multipart(form_data)
-                    .send()?;
+                let response = self.send(
+                        self.client
+                            .post(&self.route(concat!("/api/v1/", $url)))
+                            .multipart(form_data)
+                )?;
 
                 let status = response.status().clone();
 
@@ -90,10 +91,10 @@ macro_rules! route {
                     )*
                 });
 
-                let response = self.client.$method(&self.route(concat!("/api/v1/", $url)))
-                    .headers(self.headers.clone())
-                    .json(&form_data)
-                    .send()?;
+                let response = self.send(
+                        self.client.$method(&self.route(concat!("/api/v1/", $url)))
+                            .json(&form_data)
+                )?;
 
                 let status = response.status().clone();
 
@@ -152,11 +153,11 @@ macro_rules! paged_routes_with_id {
                 "Equivalent to `/api/v1/",
                 $url,
                 "`\n# Errors\nIf `access_token` is not set."),
-            fn $name(&self, id: &str) -> Result<Page<$ret>> {
+            fn $name(&self, id: &str) -> Result<Page<$ret, H>> {
                 let url = self.route(&format!(concat!("/api/v1/", $url), id));
-                let response = self.client.$method(&url)
-                    .headers(self.headers.clone())
-                    .send()?;
+                let response = self.send(
+                        &mut self.client.$method(&url)
+                )?;
 
                 Page::new(self, response)
             }

--- a/src/registration.rs
+++ b/src/registration.rs
@@ -2,12 +2,12 @@ use reqwest::{Client, RequestBuilder, Response};
 use try_from::TryInto;
 
 use apps::{App, Scopes};
+use http_send::{HttpSend, HttpSender};
 use Data;
 use Error;
 use Mastodon;
 use MastodonBuilder;
 use Result;
-use http_send::{HttpSend, HttpSender};
 
 /// Handles registering your mastodon app to your instance. It is recommended
 /// you cache your data struct to avoid registering on every run.
@@ -56,15 +56,12 @@ impl<H: HttpSend> Registration<H> {
         Registration {
             base: base.into(),
             client: Client::new(),
-            http_sender: http_sender,
+            http_sender,
         }
     }
 
     fn send(&self, req: &mut RequestBuilder) -> Result<Response> {
-        Ok(self.http_sender.send(
-                &self.client,
-                req
-        )?)
+        Ok(self.http_sender.send(&self.client, req)?)
     }
 
     /// Register the application with the server from the `base` url.
@@ -96,9 +93,7 @@ impl<H: HttpSend> Registration<H> {
     {
         let app = app.try_into()?;
         let url = format!("{}/api/v1/apps", self.base);
-        let oauth: OAuth = self.send(
-                self.client.post(&url).form(&app)
-        )?.json()?;
+        let oauth: OAuth = self.send(self.client.post(&url).form(&app))?.json()?;
 
         Ok(Registered {
             base: self.base,
@@ -114,10 +109,7 @@ impl<H: HttpSend> Registration<H> {
 
 impl<H: HttpSend> Registered<H> {
     fn send(&self, req: &mut RequestBuilder) -> Result<Response> {
-        Ok(self.http_sender.send(
-                &self.client,
-                req
-        )?)
+        Ok(self.http_sender.send(&self.client, req)?)
     }
 
     /// Returns the full url needed for authorisation. This needs to be opened
@@ -143,9 +135,7 @@ impl<H: HttpSend> Registered<H> {
             self.redirect
         );
 
-        let token: AccessToken = self.send(
-                &mut self.client.post(&url)
-        )?.json()?;
+        let token: AccessToken = self.send(&mut self.client.post(&url))?.json()?;
 
         let data = Data {
             base: self.base.into(),


### PR DESCRIPTION
Parameterize everything that involves sending HTTP requests with the `H:
HttpSend` bound. This will allow us to swap out `HttpSend`
implementations when necessary, in order to better test our code