### PR TITLE
Remove `elefren::apps::prelude`

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ use std::io;
 use std::error::Error;
 
 use elefren::prelude::*;
-use elefren::apps::prelude::*;
 use elefren::helpers::toml; // requires `features = ["toml"]`
 
 fn main() -> Result<(), Box<Error>> {

--- a/examples/register.rs
+++ b/examples/register.rs
@@ -2,7 +2,7 @@
 #![cfg_attr(not(feature = "toml"), allow(unused_imports))]
 extern crate elefren;
 
-pub use self::elefren::{apps::prelude::*, prelude::*};
+pub use self::elefren::prelude::*;
 
 use std::{error::Error, io};
 

--- a/src/apps.rs
+++ b/src/apps.rs
@@ -2,13 +2,6 @@ use std::{borrow::Cow, fmt};
 
 use errors::{Error, Result};
 
-/// Provides the necessary types for registering an App and getting the
-/// necessary auth information
-pub mod prelude {
-    pub use apps::{App, Scopes};
-    pub use registration::Registration;
-}
-
 /// Represents an application that can be registered with a mastodon instance
 #[derive(Debug, Default, Serialize)]
 pub struct App {
@@ -31,7 +24,7 @@ impl App {
 
 /// Builder struct for defining your application.
 /// ```
-/// use elefren::apps::prelude::*;
+/// use elefren::apps::App;
 /// use std::error::Error;
 ///
 /// # fn main() -> Result<(), Box<Error>> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,11 +86,11 @@ pub mod status_builder;
 mod macros;
 /// Automatically import the things you need
 pub mod prelude {
+    pub use apps::Scopes;
     pub use Data;
     pub use Mastodon;
     pub use MastodonClient;
     pub use Registration;
-    pub use apps::Scopes;
     pub use StatusBuilder;
     pub use StatusesRequest;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@
 //! #    try().unwrap();
 //! # }
 //! # fn try() -> elefren::Result<()> {
-//! use elefren::{apps::prelude::*, prelude::*};
+//! use elefren::prelude::*;
 //!
 //! let registration = Registration::new("https://mastodon.social")
 //!     .client_name("elefren_test")
@@ -86,9 +86,11 @@ pub mod status_builder;
 mod macros;
 /// Automatically import the things you need
 pub mod prelude {
-    pub use data::Data;
+    pub use Data;
     pub use Mastodon;
     pub use MastodonClient;
+    pub use Registration;
+    pub use apps::Scopes;
     pub use StatusBuilder;
     pub use StatusesRequest;
 }

--- a/src/registration.rs
+++ b/src/registration.rs
@@ -38,7 +38,7 @@ struct AccessToken {
 impl<'a> Registration<'a, HttpSender> {
     /// Construct a new registration process to the instance of the `base` url.
     /// ```
-    /// use elefren::apps::prelude::*;
+    /// use elefren::prelude::*;
     ///
     /// let registration = Registration::new("https://mastodon.social");
     /// ```
@@ -92,7 +92,7 @@ impl<'a, H: HttpSend> Registration<'a, H> {
     /// ```no_run
     /// # extern crate elefren;
     /// # fn main () -> elefren::Result<()> {
-    /// use elefren::{apps::prelude::*, prelude::*};
+    /// use elefren::prelude::*;
     ///
     /// let registration = Registration::new("https://mastodon.social")
     ///     .client_name("elefren_test")


### PR DESCRIPTION
Since we don't need `App` in a prelude anymore, just move `Registration`
and `Scopes` to the main prelude and get rid of `elefren::apps::prelude`