### PR TITLE
Rework the `Registration` and `App` APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ fn main() -> Result<(), Box<Error>> {
 fn register() -> Result<Mastodon, Box<Error>> {
     let registration = Registration::new("https://mastodon.social")
                                     .client_name("elefren-examples")
-                                    .register()?;
+                                    .build()?;
     let url = registration.authorize_url()?;
 
     println!("Click this link to authorize on Mastodon: {}", url);

--- a/examples/register.rs
+++ b/examples/register.rs
@@ -33,7 +33,7 @@ pub fn register() -> Result<Mastodon, Box<Error>> {
         .client_name("elefren-examples")
         .scopes(Scopes::All)
         .website("https://github.com/pwoolcoc/elefren")
-        .register()?;
+        .build()?;
     let url = registration.authorize_url()?;
 
     println!("Click this link to authorize on Mastodon: {}", url);

--- a/src/apps.rs
+++ b/src/apps.rs
@@ -1,5 +1,7 @@
 use std::{borrow::Cow, fmt};
 
+use try_from::TryInto;
+
 use errors::{Error, Result};
 
 /// Represents an application that can be registered with a mastodon instance
@@ -94,6 +96,22 @@ impl<'a> AppBuilder<'a> {
             scopes: self.scopes.unwrap_or_else(|| Scopes::Read),
             website: self.website.map(|s| s.into()),
         })
+    }
+}
+
+impl TryInto<App> for App {
+    type Err = Error;
+
+    fn try_into(self) -> Result<App> {
+        Ok(self)
+    }
+}
+
+impl<'a> TryInto<App> for AppBuilder<'a> {
+    type Err = Error;
+
+    fn try_into(self) -> Result<App> {
+        Ok(self.build()?)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@
 //!
 //! let registration = Registration::new("https://mastodon.social")
 //!     .client_name("elefren_test")
-//!     .register()?;
+//!     .build()?;
 //! let url = registration.authorize_url()?;
 //! // Here you now need to open the url in the browser
 //! // And handle a the redirect url coming back with the code.


### PR DESCRIPTION
This puts `register` back to the way it was, and changes the "new"
`register` to `build`.