### PR TITLE
Move this to the before_script phase

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,15 +22,16 @@ rust:
 before_script:
   - |
     if [[ "$TRAVIS_RUST_VERSION" == "nightly"* ]]; then rustup component add rustfmt-preview; fi
+  - |
+    if [[ "$TRAVIS_RUST_VERSION" == stable ]] 2> /dev/null && [ -z "$ELEFREN_FEATURES" ] 2>/dev/null && [[ "$TRAVIS_OS_NAME" == "linux" ]] 2>/dev/null && [[ -z "$(which cargo-tarpaulin)" ]]; then
+      RUSTFLAGS="--cfg procmacro2_semver_exempt" cargo install cargo-tarpaulin
+    fi
 script:
   - |
     if [[ "$TRAVIS_RUST_VERSION" == "nightly"* ]]; then cargo fmt --all -- --check; fi
   - cargo test $ELEFREN_FEATURES
 after_success: |
   if [[ "$TRAVIS_RUST_VERSION" == stable ]] 2> /dev/null && [ -z "$ELEFREN_FEATURES" ] 2>/dev/null && [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-    if [[ -z "$(which cargo-tarpaulin)" ]]; then
-        RUSTFLAGS="--cfg procmacro2_semver_exempt" cargo install cargo-tarpaulin
-    fi
     cargo tarpaulin --ciserver travis-ci --coveralls $TRAVIS_JOB_ID --features toml
   fi
 matrix:


### PR DESCRIPTION
The build cache gets stored after the `script` phase, but before the
`after_success`/`after_failure` phase, so the built cargo-tarpaulin
wasn't getting cached