### PR TITLE
Add tests to requests/statuses

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -297,7 +297,8 @@ impl<H: HttpSend> MastodonClient<H> for Mastodon<H> {
     /// #   token: "".into(),
     /// # };
     /// let client = Mastodon::from(data);
-    /// let request = StatusesRequest::default().only_media();
+    /// let mut request = StatusesRequest::new();
+    /// request.only_media();
     /// let statuses = client.statuses("user-id", request)?;
     /// # Ok(())
     /// # }

--- a/src/requests/statuses.rs
+++ b/src/requests/statuses.rs
@@ -1,4 +1,4 @@
-use std::borrow::Cow;
+use std::{borrow::Cow, convert::Into};
 
 /// Builder for making a client.statuses() call
 ///
@@ -7,10 +7,11 @@ use std::borrow::Cow;
 /// ```
 /// # extern crate elefren;
 /// # use elefren::StatusesRequest;
-/// let request = StatusesRequest::new().only_media().pinned().since_id("foo");
+/// let mut request = StatusesRequest::new();
+/// request.only_media().pinned().since_id("foo");
 /// # assert_eq!(&request.to_querystring()[..], "?only_media=1&pinned=1&since_id=foo");
 /// ```
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct StatusesRequest<'a> {
     only_media: bool,
     exclude_replies: bool,
@@ -18,6 +19,19 @@ pub struct StatusesRequest<'a> {
     max_id: Option<Cow<'a, str>>,
     since_id: Option<Cow<'a, str>>,
     limit: Option<usize>,
+}
+
+impl<'a> Into<Option<StatusesRequest<'a>>> for &'a mut StatusesRequest<'a> {
+    fn into(self) -> Option<StatusesRequest<'a>> {
+        Some(StatusesRequest {
+            only_media: self.only_media,
+            exclude_replies: self.exclude_replies,
+            pinned: self.pinned,
+            max_id: self.max_id.clone(),
+            since_id: self.since_id.clone(),
+            limit: self.limit.clone(),
+        })
+    }
 }
 
 impl<'a> StatusesRequest<'a> {
@@ -41,9 +55,9 @@ impl<'a> StatusesRequest<'a> {
     /// ```
     /// # extern crate elefren;
     /// # use elefren::StatusesRequest;
-    /// let request = StatusesRequest::new().only_media();
-    /// assert_eq!(&request.to_querystring(), "?only_media=1");
-    pub fn only_media(mut self) -> Self {
+    /// let mut request = StatusesRequest::new();
+    /// assert_eq!(&request.only_media().to_querystring(), "?only_media=1");
+    pub fn only_media(&mut self) -> &mut Self {
         self.only_media = true;
         self
     }
@@ -55,10 +69,13 @@ impl<'a> StatusesRequest<'a> {
     /// ```
     /// # extern crate elefren;
     /// # use elefren::StatusesRequest;
-    /// let request = StatusesRequest::new().exclude_replies();
-    /// assert_eq!(&request.to_querystring(), "?exclude_replies=1");
+    /// let mut request = StatusesRequest::new();
+    /// assert_eq!(
+    ///     &request.exclude_replies().to_querystring(),
+    ///     "?exclude_replies=1"
+    /// );
     /// ```
-    pub fn exclude_replies(mut self) -> Self {
+    pub fn exclude_replies(&mut self) -> &mut Self {
         self.exclude_replies = true;
         self
     }
@@ -70,10 +87,10 @@ impl<'a> StatusesRequest<'a> {
     /// ```
     /// # extern crate elefren;
     /// # use elefren::StatusesRequest;
-    /// let request = StatusesRequest::new().pinned();
-    /// assert_eq!(&request.to_querystring(), "?pinned=1");
+    /// let mut request = StatusesRequest::new();
+    /// assert_eq!(&request.pinned().to_querystring(), "?pinned=1");
     /// ```
-    pub fn pinned(mut self) -> Self {
+    pub fn pinned(&mut self) -> &mut Self {
         self.pinned = true;
         self
     }
@@ -85,10 +102,10 @@ impl<'a> StatusesRequest<'a> {
     /// ```
     /// # extern crate elefren;
     /// # use elefren::StatusesRequest;
-    /// let request = StatusesRequest::new().max_id("foo");
-    /// assert_eq!(&request.to_querystring(), "?max_id=foo");
+    /// let mut request = StatusesRequest::new();
+    /// assert_eq!(&request.max_id("foo").to_querystring(), "?max_id=foo");
     /// ```
-    pub fn max_id<S: Into<Cow<'a, str>>>(mut self, max_id: S) -> Self {
+    pub fn max_id<S: Into<Cow<'a, str>>>(&mut self, max_id: S) -> &mut Self {
         self.max_id = Some(max_id.into());
         self
     }
@@ -100,10 +117,10 @@ impl<'a> StatusesRequest<'a> {
     /// ```
     /// # extern crate elefren;
     /// # use elefren::StatusesRequest;
-    /// let request = StatusesRequest::new().since_id("foo");
-    /// assert_eq!(&request.to_querystring(), "?since_id=foo");
+    /// let mut request = StatusesRequest::new();
+    /// assert_eq!(&request.since_id("foo").to_querystring(), "?since_id=foo");
     /// ```
-    pub fn since_id<S: Into<Cow<'a, str>>>(mut self, since_id: S) -> Self {
+    pub fn since_id<S: Into<Cow<'a, str>>>(&mut self, since_id: S) -> &mut Self {
         self.since_id = Some(since_id.into());
         self
     }
@@ -115,10 +132,10 @@ impl<'a> StatusesRequest<'a> {
     /// ```
     /// # extern crate elefren;
     /// # use elefren::StatusesRequest;
-    /// let request = StatusesRequest::new().limit(10);
-    /// assert_eq!(&request.to_querystring(), "?limit=10");
+    /// let mut request = StatusesRequest::new();
+    /// assert_eq!(&request.limit(10).to_querystring(), "?limit=10");
     /// ```
-    pub fn limit(mut self, limit: usize) -> Self {
+    pub fn limit(&mut self, limit: usize) -> &mut Self {
         self.limit = Some(limit);
         self
     }
@@ -130,8 +147,11 @@ impl<'a> StatusesRequest<'a> {
     /// ```
     /// # extern crate elefren;
     /// # use elefren::StatusesRequest;
-    /// let request = StatusesRequest::new().limit(10).pinned();
-    /// assert_eq!(&request.to_querystring(), "?pinned=1&limit=10");
+    /// let mut request = StatusesRequest::new();
+    /// assert_eq!(
+    ///     &request.limit(10).pinned().to_querystring(),
+    ///     "?pinned=1&limit=10"
+    /// );
     /// ```
     pub fn to_querystring(&self) -> String {
         let mut opts = vec![];
@@ -165,5 +185,354 @@ impl<'a> StatusesRequest<'a> {
         } else {
             format!("?{}", opts.join("&"))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new() {
+        let request = StatusesRequest::new();
+        assert_eq!(
+            request,
+            StatusesRequest {
+                only_media: false,
+                exclude_replies: false,
+                pinned: false,
+                max_id: None,
+                since_id: None,
+                limit: None,
+            }
+        );
+    }
+
+    #[test]
+    fn test_only_media() {
+        let mut request = StatusesRequest::new();
+        request.only_media();
+        assert_eq!(
+            request,
+            StatusesRequest {
+                only_media: true,
+                exclude_replies: false,
+                pinned: false,
+                max_id: None,
+                since_id: None,
+                limit: None,
+            }
+        );
+    }
+
+    #[test]
+    fn test_exclude_replies() {
+        let mut request = StatusesRequest::new();
+        request.exclude_replies();
+        assert_eq!(
+            request,
+            StatusesRequest {
+                only_media: false,
+                exclude_replies: true,
+                pinned: false,
+                max_id: None,
+                since_id: None,
+                limit: None,
+            }
+        );
+    }
+    #[test]
+    fn test_pinned() {
+        let mut request = StatusesRequest::new();
+        request.pinned();
+        assert_eq!(
+            request,
+            StatusesRequest {
+                only_media: false,
+                exclude_replies: false,
+                pinned: true,
+                max_id: None,
+                since_id: None,
+                limit: None,
+            }
+        );
+    }
+    #[test]
+    fn test_max_id() {
+        let mut request = StatusesRequest::new();
+        request.max_id("foo");
+        assert_eq!(
+            request,
+            StatusesRequest {
+                only_media: false,
+                exclude_replies: false,
+                pinned: false,
+                max_id: Some("foo".into()),
+                since_id: None,
+                limit: None,
+            }
+        );
+    }
+    #[test]
+    fn test_since_id() {
+        let mut request = StatusesRequest::new();
+        request.since_id("foo");
+        assert_eq!(
+            request,
+            StatusesRequest {
+                only_media: false,
+                exclude_replies: false,
+                pinned: false,
+                max_id: None,
+                since_id: Some("foo".into()),
+                limit: None,
+            }
+        );
+    }
+    #[test]
+    fn test_limit() {
+        let mut request = StatusesRequest::new();
+        request.limit(42);
+        assert_eq!(
+            request,
+            StatusesRequest {
+                only_media: false,
+                exclude_replies: false,
+                pinned: false,
+                max_id: None,
+                since_id: None,
+                limit: Some(42),
+            }
+        );
+    }
+    #[test]
+    fn test_to_querystring() {
+        macro_rules! qs_test {
+            (|$r:ident| $b:block, $expected:expr) => {
+                {
+                    let mut $r = StatusesRequest::new();
+                    $b
+                    let qs = $r.to_querystring();
+                    assert_eq!(&qs, $expected);
+                }
+            }
+        }
+
+        qs_test!(
+            |request| {
+                request.only_media();
+            },
+            "?only_media=1"
+        );
+        qs_test!(
+            |request| {
+                request.exclude_replies();
+            },
+            "?exclude_replies=1"
+        );
+        qs_test!(
+            |request| {
+                request.pinned();
+            },
+            "?pinned=1"
+        );
+        qs_test!(
+            |request| {
+                request.max_id("foo");
+            },
+            "?max_id=foo"
+        );
+        qs_test!(
+            |request| {
+                request.since_id("foo");
+            },
+            "?since_id=foo"
+        );
+        qs_test!(
+            |request| {
+                request.limit(42);
+            },
+            "?limit=42"
+        );
+        qs_test!(
+            |request| {
+                request.only_media().exclude_replies();
+            },
+            "?only_media=1&exclude_replies=1"
+        );
+        qs_test!(
+            |request| {
+                request.only_media().pinned();
+            },
+            "?only_media=1&pinned=1"
+        );
+        qs_test!(
+            |request| {
+                request.only_media().max_id("foo");
+            },
+            "?only_media=1&max_id=foo"
+        );
+        qs_test!(
+            |request| {
+                request.only_media().since_id("foo");
+            },
+            "?only_media=1&since_id=foo"
+        );
+        qs_test!(
+            |request| {
+                request.only_media().limit(42);
+            },
+            "?only_media=1&limit=42"
+        );
+        qs_test!(
+            |request| {
+                request.exclude_replies().only_media();
+            },
+            "?only_media=1&exclude_replies=1"
+        );
+        qs_test!(
+            |request| {
+                request.exclude_replies().pinned();
+            },
+            "?exclude_replies=1&pinned=1"
+        );
+        qs_test!(
+            |request| {
+                request.exclude_replies().max_id("foo");
+            },
+            "?exclude_replies=1&max_id=foo"
+        );
+        qs_test!(
+            |request| {
+                request.exclude_replies().since_id("foo");
+            },
+            "?exclude_replies=1&since_id=foo"
+        );
+        qs_test!(
+            |request| {
+                request.exclude_replies().limit(42);
+            },
+            "?exclude_replies=1&limit=42"
+        );
+        qs_test!(
+            |request| {
+                request.pinned().only_media();
+            },
+            "?only_media=1&pinned=1"
+        );
+        qs_test!(
+            |request| {
+                request.pinned().exclude_replies();
+            },
+            "?exclude_replies=1&pinned=1"
+        );
+        qs_test!(
+            |request| {
+                request.pinned().max_id("foo");
+            },
+            "?pinned=1&max_id=foo"
+        );
+        qs_test!(
+            |request| {
+                request.pinned().since_id("foo");
+            },
+            "?pinned=1&since_id=foo"
+        );
+        qs_test!(
+            |request| {
+                request.pinned().limit(42);
+            },
+            "?pinned=1&limit=42"
+        );
+        qs_test!(
+            |request| {
+                request.max_id("foo").only_media();
+            },
+            "?only_media=1&max_id=foo"
+        );
+        qs_test!(
+            |request| {
+                request.max_id("foo").exclude_replies();
+            },
+            "?exclude_replies=1&max_id=foo"
+        );
+        qs_test!(
+            |request| {
+                request.max_id("foo").pinned();
+            },
+            "?pinned=1&max_id=foo"
+        );
+        qs_test!(
+            |request| {
+                request.max_id("foo").since_id("foo");
+            },
+            "?max_id=foo&since_id=foo"
+        );
+        qs_test!(
+            |request| {
+                request.max_id("foo").limit(42);
+            },
+            "?max_id=foo&limit=42"
+        );
+        qs_test!(
+            |request| {
+                request.since_id("foo").only_media();
+            },
+            "?only_media=1&since_id=foo"
+        );
+        qs_test!(
+            |request| {
+                request.since_id("foo").exclude_replies();
+            },
+            "?exclude_replies=1&since_id=foo"
+        );
+        qs_test!(
+            |request| {
+                request.since_id("foo").pinned();
+            },
+            "?pinned=1&since_id=foo"
+        );
+        qs_test!(
+            |request| {
+                request.since_id("foo").max_id("foo");
+            },
+            "?max_id=foo&since_id=foo"
+        );
+        qs_test!(
+            |request| {
+                request.since_id("foo").limit(42);
+            },
+            "?since_id=foo&limit=42"
+        );
+        qs_test!(
+            |request| {
+                request.limit(42).only_media();
+            },
+            "?only_media=1&limit=42"
+        );
+        qs_test!(
+            |request| {
+                request.limit(42).exclude_replies();
+            },
+            "?exclude_replies=1&limit=42"
+        );
+        qs_test!(
+            |request| {
+                request.limit(42).pinned();
+            },
+            "?pinned=1&limit=42"
+        );
+        qs_test!(
+            |request| {
+                request.limit(42).max_id("foo");
+            },
+            "?max_id=foo&limit=42"
+        );
+        qs_test!(
+            |request| {
+                request.limit(42).since_id("foo");
+            },
+            "?since_id=foo&limit=42"
+        );
     }
 }


### PR DESCRIPTION
Need to figure out a better solution for that to_querystring test, it'd
be nice to have something generate every possible permutation of those
builder methods