### PR TITLE
Keyword/filtering API

### DIFF
--- a/src/entities/filter.rs
+++ b/src/entities/filter.rs
@@ -1,0 +1,27 @@
+/// Represents a single Filter
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Filter {
+    id: String,
+    phrase: String,
+    context: Vec<FilterContext>,
+    expires_at: Option<String>, // TODO: timestamp
+    irreversible: bool,
+    whole_word: bool,
+}
+
+/// Represents the various types of Filter contexts
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub enum FilterContext {
+    /// Represents the "home" context
+    #[serde(rename = "home")]
+    Home,
+    /// Represents the "notifications" context
+    #[serde(rename = "notifications")]
+    Notifications,
+    /// Represents the "public" context
+    #[serde(rename = "public")]
+    Public,
+    /// Represents the "thread" context
+    #[serde(rename = "thread")]
+    Thread,
+}

--- a/src/entities/mod.rs
+++ b/src/entities/mod.rs
@@ -6,6 +6,8 @@ pub mod attachment;
 pub mod card;
 /// Data structures for ser/de of contetx-related resources
 pub mod context;
+/// Data structures for ser/de of filter-related resources
+pub mod filter;
 /// Data structures for ser/de of instance-related resources
 pub mod instance;
 pub(crate) mod itemsiter;
@@ -39,6 +41,7 @@ pub mod prelude {
         attachment::{Attachment, MediaType},
         card::Card,
         context::Context,
+        filter::{Filter, FilterContext},
         instance::*,
         list::List,
         mention::Mention,

--- a/src/mastodon_client.rs
+++ b/src/mastodon_client.rs
@@ -4,7 +4,13 @@ use entities::prelude::*;
 use errors::Result;
 use http_send::{HttpSend, HttpSender};
 use page::Page;
-use requests::{AddPushRequest, StatusesRequest, UpdateCredsRequest, UpdatePushRequest};
+use requests::{
+    AddFilterRequest,
+    AddPushRequest,
+    StatusesRequest,
+    UpdateCredsRequest,
+    UpdatePushRequest,
+};
 use status_builder::StatusBuilder;
 
 /// Represents the set of methods that a Mastodon Client can do, so that
@@ -225,6 +231,26 @@ pub trait MastodonClient<H: HttpSend = HttpSender> {
     }
     /// DELETE /api/v1/push/subscription
     fn delete_push_subscription(&self) -> Result<Empty> {
+        unimplemented!("This method was not implemented");
+    }
+    /// GET /api/v1/filters
+    fn get_filters(&self) -> Result<Vec<Filter>> {
+        unimplemented!("This method was not implemented");
+    }
+    /// POST /api/v1/filters
+    fn add_filter(&self, request: &mut AddFilterRequest) -> Result<Filter> {
+        unimplemented!("This method was not implemented");
+    }
+    /// GET /api/v1/filters/:id
+    fn get_filter(&self, id: u64) -> Result<Filter> {
+        unimplemented!("This method was not implemented");
+    }
+    /// PUT /api/v1/filters/:id
+    fn update_filter(&self, id: u64, request: &mut AddFilterRequest) -> Result<Filter> {
+        unimplemented!("This method was not implemented");
+    }
+    /// DELETE /api/v1/filters/:id
+    fn delete_filter(&self, id: u64) -> Result<Empty> {
         unimplemented!("This method was not implemented");
     }
 }

--- a/src/requests/filter.rs
+++ b/src/requests/filter.rs
@@ -1,0 +1,154 @@
+use entities::filter::FilterContext;
+use std::time::Duration;
+
+/// Form used to create a filter
+///
+/// # Example
+///
+/// ```
+/// # extern crate elefren;
+/// # use std::error::Error;
+/// use elefren::{entities::filter::FilterContext, requests::AddFilterRequest};
+/// # fn main() -> Result<(), Box<Error>> {
+/// let request = AddFilterRequest::new("foo", FilterContext::Home);
+/// #   Ok(())
+/// # }
+/// ```
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct AddFilterRequest {
+    phrase: String,
+    context: FilterContext,
+    irreversible: Option<bool>,
+    whole_word: Option<bool>,
+    #[serde(serialize_with = "serialize_duration::ser")]
+    expires_in: Option<Duration>,
+}
+
+impl AddFilterRequest {
+    /// Create a new AddFilterRequest
+    pub fn new(phrase: &str, context: FilterContext) -> AddFilterRequest {
+        AddFilterRequest {
+            phrase: phrase.to_string(),
+            context,
+            irreversible: None,
+            whole_word: None,
+            expires_in: None,
+        }
+    }
+
+    /// Set `irreversible` to `true`
+    pub fn irreversible(&mut self) -> &mut Self {
+        self.irreversible = Some(true);
+        self
+    }
+
+    /// Set `whole_word` to `true`
+    pub fn whole_word(&mut self) -> &mut Self {
+        self.whole_word = Some(true);
+        self
+    }
+
+    /// Set `expires_in` to a duration
+    pub fn expires_in(&mut self, d: Duration) -> &mut Self {
+        self.expires_in = Some(d);
+        self
+    }
+}
+
+mod serialize_duration {
+    use serde::ser::Serializer;
+    use std::time::Duration;
+
+    pub(crate) fn ser<S>(duration: &Option<Duration>, s: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        if let Some(d) = duration {
+            let sec = d.as_secs();
+            s.serialize_u64(sec)
+        } else {
+            s.serialize_none()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json;
+    use std::time::Duration;
+
+    #[test]
+    fn test_new() {
+        let request = AddFilterRequest::new("foo", FilterContext::Home);
+        assert_eq!(
+            request,
+            AddFilterRequest {
+                phrase: "foo".to_string(),
+                context: FilterContext::Home,
+                irreversible: None,
+                whole_word: None,
+                expires_in: None,
+            }
+        )
+    }
+
+    #[test]
+    fn test_irreversible() {
+        let mut request = AddFilterRequest::new("foo", FilterContext::Home);
+        request.irreversible();
+        assert_eq!(
+            request,
+            AddFilterRequest {
+                phrase: "foo".to_string(),
+                context: FilterContext::Home,
+                irreversible: Some(true),
+                whole_word: None,
+                expires_in: None,
+            }
+        )
+    }
+
+    #[test]
+    fn test_whole_word() {
+        let mut request = AddFilterRequest::new("foo", FilterContext::Home);
+        request.whole_word();
+        assert_eq!(
+            request,
+            AddFilterRequest {
+                phrase: "foo".to_string(),
+                context: FilterContext::Home,
+                irreversible: None,
+                whole_word: Some(true),
+                expires_in: None,
+            }
+        )
+    }
+
+    #[test]
+    fn test_expires_in() {
+        let mut request = AddFilterRequest::new("foo", FilterContext::Home);
+        request.expires_in(Duration::from_secs(300));
+        assert_eq!(
+            request,
+            AddFilterRequest {
+                phrase: "foo".to_string(),
+                context: FilterContext::Home,
+                irreversible: None,
+                whole_word: None,
+                expires_in: Some(Duration::from_secs(300)),
+            }
+        )
+    }
+
+    #[test]
+    fn test_serialize_request() {
+        let mut request = AddFilterRequest::new("foo", FilterContext::Home);
+        request.expires_in(Duration::from_secs(300));
+        let ser = serde_json::to_string(&request).expect("Couldn't serialize");
+        assert_eq!(
+            ser,
+            r#"{"phrase":"foo","context":"home","irreversible":null,"whole_word":null,"expires_in":300}"#
+        )
+    }
+}

--- a/src/requests/mod.rs
+++ b/src/requests/mod.rs
@@ -1,3 +1,5 @@
+/// Data structure for the MastodonClient::add_filter method
+pub use self::filter::AddFilterRequest;
 /// Data structure for the MastodonClient::add_push_subscription method
 pub use self::push::{AddPushRequest, Keys, UpdatePushRequest};
 /// Data structure for the MastodonClient::statuses method
@@ -5,6 +7,7 @@ pub use self::statuses::StatusesRequest;
 /// Data structure for the MastodonClient::update_credentials method
 pub use self::update_credentials::UpdateCredsRequest;
 
+mod filter;
 mod push;
 mod statuses;
 mod update_credentials;


### PR DESCRIPTION
This adds the 5 methods for the mastodon API that deal with keyword
filtering:

GET /api/v1/filters
POST /api/v1/filters
GET /api/v1/filters/:id
PUT /api/v1/filters/:id
DELETE /api/v1/filters/:id

Closes #71