### PR TITLE
account: Properly mark nullable source fields

### DIFF
--- a/src/entities/account.rs
+++ b/src/entities/account.rs
@@ -70,10 +70,10 @@ impl MetadataField {
 /// An extra object given from `verify_credentials` giving defaults about a user
 #[derive(Debug, Clone, Deserialize, PartialEq)]
 pub struct Source {
-    privacy: status_builder::Visibility,
+    privacy: Option<status_builder::Visibility>,
     #[serde(deserialize_with = "string_or_bool")]
     sensitive: bool,
-    note: String,
+    note: Option<String>,
     fields: Option<Vec<MetadataField>>,
 }
 


### PR DESCRIPTION
Privacy and note are both nullable according to
https://source.joinmastodon.org/mastodon/docs/blob/master/content/en/api/entities.md#source

This is causing a crash in Social right now because serde expects these fields to be there, but Pleroma doesn't always return them.