### PR TITLE
Add content_type support to StatusBuilder

### DIFF
--- a/src/status_builder.rs
+++ b/src/status_builder.rs
@@ -25,6 +25,7 @@ pub struct StatusBuilder {
     media_ids: Option<Vec<String>>,
     sensitive: Option<bool>,
     spoiler_text: Option<String>,
+    content_type: Option<String>,
     visibility: Option<Visibility>,
     language: Option<Language>,
 }
@@ -150,6 +151,35 @@ impl StatusBuilder {
         self
     }
 
+    /// Set the content type of the post
+    ///
+    /// This is a Pleroma and Glitch-soc extension of the API.
+    ///
+    /// # Possible values
+    /// - `text/plain`
+    /// - `text/html`
+    /// - `text/markdown`
+    /// - `text/bbcode` (Pleroma only)
+    ///
+    /// The set of supported content types may vary by server.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use elefren::prelude::*;
+    /// # fn main() -> Result<(), elefren::Error> {
+    /// let status = StatusBuilder::new()
+    ///     .status("<b>thicc</b>")
+    ///     .content_type("text/html")
+    ///     .build()?;
+    /// #   Ok(())
+    /// # }
+    /// ```
+    pub fn content_type<I: Into<String>>(&mut self, content_type: I) -> &mut Self {
+        self.content_type = Some(content_type.into());
+        self
+    }
+
     /// Set the visibility for the post
     ///
     /// # Example
@@ -215,6 +245,7 @@ impl StatusBuilder {
             spoiler_text: self.spoiler_text.clone(),
             visibility: self.visibility.clone(),
             language: self.language.clone(),
+            content_type: self.content_type.clone(),
         })
     }
 }
@@ -236,6 +267,8 @@ pub struct NewStatus {
     visibility: Option<Visibility>,
     #[serde(skip_serializing_if = "Option::is_none")]
     language: Option<Language>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    content_type: Option<String>,
 }
 
 /// The visibility of a status.
@@ -278,6 +311,7 @@ mod tests {
             spoiler_text: None,
             visibility: None,
             language: None,
+            content_type: None,
         };
         assert_eq!(s, expected);
     }


### PR DESCRIPTION
Adds the Pleroma and Glitch-soc extension to choose new post's content type.