### PR TITLE
Make fields of MetadataField exposed to public

### DIFF
--- a/src/entities/account.rs
+++ b/src/entities/account.rs
@@ -54,8 +54,8 @@ pub struct Account {
 /// A single name: value pair from a user's profile
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
 pub struct MetadataField {
-    name: String,
-    value: String,
+    pub name: String,
+    pub value: String,
 }
 
 impl MetadataField {

--- a/src/entities/account.rs
+++ b/src/entities/account.rs
@@ -54,7 +54,9 @@ pub struct Account {
 /// A single name: value pair from a user's profile
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
 pub struct MetadataField {
+    /// name part of metadata
     pub name: String,
+    /// value part of metadata
     pub value: String,
 }
 


### PR DESCRIPTION
I needed to access the Metadata Fields in my application and it wouldn't let me. While the struct was defined as public, the fields were not. I changed the fields to public.