### PR TITLE
Use `slice::iter` instead of `into_iter` to avoid future breakage

### DIFF
--- a/src/scopes.rs
+++ b/src/scopes.rs
@@ -692,7 +692,7 @@ mod tests {
             "push".to_string(),
         ];
 
-        let tests = values.into_iter().zip(expecteds.into_iter());
+        let tests = values.iter().zip(expecteds.iter());
 
         for (value, expected) in tests {
             let result = value.to_string();


### PR DESCRIPTION
`an_array.into_iter()` currently just works because of the autoref
feature, which then calls `<[T] as IntoIterator>::into_iter`. But
in the future, arrays will implement `IntoIterator`, too. In order
to avoid problems in the future, the call is replaced by `iter()`
which is shorter and more explicit.

A crater run showed that your crate is affected by a potential future 
change. See https://github.com/rust-lang/rust/pull/65819 for more information.