### PR TITLE
added methods returning pages for timelines home, local, federated, hashtag

### DIFF
--- a/src/mastodon_client.rs
+++ b/src/mastodon_client.rs
@@ -196,12 +196,16 @@ pub trait MastodonClient<H: HttpSend = HttpSender> {
     fn new_status(&self, status: NewStatus) -> Result<Status> {
         unimplemented!("This method was not implemented");
     }
-    /// GET /api/v1/timelines/public
-    fn get_public_timeline(&self, local: bool) -> Result<Vec<Status>> {
+/// GET /api/v1/timelines/public?local=true
+    fn get_local_timeline(&self) -> Result<Page<Status, H>> {
+        unimplemented!("This method was not implemented");
+    }
+/// GET /api/v1/timelines/public?local=false
+    fn get_federated_timeline(&self) -> Result<Page<Status, H>> {
         unimplemented!("This method was not implemented");
     }
     /// GET /api/v1/timelines/tag/:hashtag
-    fn get_tagged_timeline(&self, hashtag: String, local: bool) -> Result<Vec<Status>> {
+    fn get_hashtag_timeline(&self, hashtag: &str, local: bool) -> Result<Page<Status, H>> {
         unimplemented!("This method was not implemented");
     }
     /// GET /api/v1/accounts/:id/statuses


### PR DESCRIPTION
I have splitted the get_public_timeline method, because:
1. I don't like passing around booleans. I prefer having descriptive method names. 
2. In the mastodon graphical interface, there isn't a checkbox to represent the `local=true` parameter. The local and federated timelines are on different pages.

get_hashtag_timeline still has the `local` parameter, because otherwise `get_federated_hashtag_timeline` would be too long.
The hashtag timeline isn't as used as the local and federated timelines anyway.

Let me know if I have to change something.