### PR TITLE
Manually updated reqwest to 10.8 and url to 2.1 and tungstenite to 0.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ url = "1"
 tap-reader = "1"
 toml = { version = "0.5.0", optional = true }
 try_from = "0.3.2"
-tungstenite = "0.10.1"
+tungstenite = "0.11.0"
 
 [dependencies.chrono]
 version = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,12 +16,12 @@ envy = { version = "0.4.0", optional = true }
 hyper-old-types = "0.11.0"
 isolang = { version = "1.0", features = ["serde_serialize"] }
 log = "0.4.6"
-reqwest = { version = "0.9", default-features = false }
+reqwest = { version = "0.10.8", default-features = false, features = ["json", "blocking"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_urlencoded = "0.6.1"
 serde_qs = "0.6.0"
-url = "1"
+url = "2.1.1"
 tap-reader = "1"
 toml = { version = "0.5.0", optional = true }
 try_from = "0.3.2"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -182,7 +182,7 @@ mod tests {
 
     #[test]
     fn from_http_error() {
-        let err: HttpError = reqwest::get("not an actual URL").unwrap_err();
+        let err: HttpError = reqwest::blocking::get("not an actual URL").unwrap_err();
         let err: Error = Error::from(err);
         assert_is!(err, Error::Http(..));
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,7 +73,7 @@
 
 use std::{borrow::Cow, io::BufRead, ops};
 
-use reqwest::{Client, RequestBuilder, Response};
+use reqwest::blocking::{Client, RequestBuilder, Response};
 use tap_reader::Tap;
 use tungstenite::client::AutoStream;
 
@@ -461,7 +461,10 @@ impl MastodonClient for Mastodon {
         url.query_pairs_mut()
             .append_pair("access_token", &self.token)
             .append_pair("stream", "user");
-        let mut url: url::Url = reqwest::get(url.as_str())?.url().as_str().parse()?;
+        let mut url: url::Url = reqwest::blocking::get(url.as_str())?
+            .url()
+            .as_str()
+            .parse()?;
         let new_scheme = match url.scheme() {
             "http" => "ws",
             "https" => "wss",
@@ -481,7 +484,10 @@ impl MastodonClient for Mastodon {
         url.query_pairs_mut()
             .append_pair("access_token", &self.token)
             .append_pair("stream", "public");
-        let mut url: url::Url = reqwest::get(url.as_str())?.url().as_str().parse()?;
+        let mut url: url::Url = reqwest::blocking::get(url.as_str())?
+            .url()
+            .as_str()
+            .parse()?;
         let new_scheme = match url.scheme() {
             "http" => "ws",
             "https" => "wss",
@@ -501,7 +507,10 @@ impl MastodonClient for Mastodon {
         url.query_pairs_mut()
             .append_pair("access_token", &self.token)
             .append_pair("stream", "public:local");
-        let mut url: url::Url = reqwest::get(url.as_str())?.url().as_str().parse()?;
+        let mut url: url::Url = reqwest::blocking::get(url.as_str())?
+            .url()
+            .as_str()
+            .parse()?;
         let new_scheme = match url.scheme() {
             "http" => "ws",
             "https" => "wss",
@@ -522,7 +531,10 @@ impl MastodonClient for Mastodon {
             .append_pair("access_token", &self.token)
             .append_pair("stream", "hashtag")
             .append_pair("tag", hashtag);
-        let mut url: url::Url = reqwest::get(url.as_str())?.url().as_str().parse()?;
+        let mut url: url::Url = reqwest::blocking::get(url.as_str())?
+            .url()
+            .as_str()
+            .parse()?;
         let new_scheme = match url.scheme() {
             "http" => "ws",
             "https" => "wss",
@@ -543,7 +555,10 @@ impl MastodonClient for Mastodon {
             .append_pair("access_token", &self.token)
             .append_pair("stream", "hashtag:local")
             .append_pair("tag", hashtag);
-        let mut url: url::Url = reqwest::get(url.as_str())?.url().as_str().parse()?;
+        let mut url: url::Url = reqwest::blocking::get(url.as_str())?
+            .url()
+            .as_str()
+            .parse()?;
         let new_scheme = match url.scheme() {
             "http" => "ws",
             "https" => "wss",
@@ -564,7 +579,10 @@ impl MastodonClient for Mastodon {
             .append_pair("access_token", &self.token)
             .append_pair("stream", "list")
             .append_pair("list", list_id);
-        let mut url: url::Url = reqwest::get(url.as_str())?.url().as_str().parse()?;
+        let mut url: url::Url = reqwest::blocking::get(url.as_str())?
+            .url()
+            .as_str()
+            .parse()?;
         let new_scheme = match url.scheme() {
             "http" => "ws",
             "https" => "wss",
@@ -584,7 +602,10 @@ impl MastodonClient for Mastodon {
         url.query_pairs_mut()
             .append_pair("access_token", &self.token)
             .append_pair("stream", "direct");
-        let mut url: url::Url = reqwest::get(url.as_str())?.url().as_str().parse()?;
+        let mut url: url::Url = reqwest::blocking::get(url.as_str())?
+            .url()
+            .as_str()
+            .parse()?;
         let new_scheme = match url.scheme() {
             "http" => "ws",
             "https" => "wss",
@@ -600,7 +621,7 @@ impl MastodonClient for Mastodon {
 
     /// Equivalent to /api/v1/media
     fn media(&self, media_builder: MediaBuilder) -> Result<Attachment> {
-        use reqwest::multipart::Form;
+        use reqwest::blocking::multipart::Form;
 
         let mut form_data = Form::new().file("file", media_builder.file.as_ref())?;
 
@@ -808,7 +829,10 @@ impl MastodonUnauth {
     pub fn streaming_public(&self) -> Result<EventReader<WebSocket>> {
         let mut url: url::Url = self.route("/api/v1/streaming/public/local")?;
         url.query_pairs_mut().append_pair("stream", "public");
-        let mut url: url::Url = reqwest::get(url.as_str())?.url().as_str().parse()?;
+        let mut url: url::Url = reqwest::blocking::get(url.as_str())?
+            .url()
+            .as_str()
+            .parse()?;
         let new_scheme = match url.scheme() {
             "http" => "ws",
             "https" => "wss",

--- a/src/page.rs
+++ b/src/page.rs
@@ -1,7 +1,7 @@
 use super::{deserialise, Mastodon, Result};
 use crate::entities::itemsiter::ItemsIter;
 use hyper_old_types::header::{parsing, Link, RelationType};
-use reqwest::{header::LINK, Response};
+use reqwest::{blocking::Response, header::LINK};
 use serde::Deserialize;
 use url::Url;
 


### PR DESCRIPTION
I had to update url at the same time of reqwest, because didn't compile when using url v1.

In `registration.rs` I've removed `use url::percent_encoding::{utf8_percent_encode, DEFAULT_ENCODE_SET};` since it's no longer available in url v2