### PR TITLE
Async client

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,11 @@ toml = { version = "0.5.0", optional = true }
 tungstenite = "0.11.0"
 async-trait = "0.1.40"
 tokio = "0.2.22"
+async-h1 = { version = "2.1.2", optional = true }
+async-native-tls = { version = "0.3.3", optional = true }
+smol = { version = "1.2.2", optional = true }
+http-types = { version = "2.5.0", optional = true }
+async-mutex = { version = "1.4.0", optional = true }
 
 [dependencies.chrono]
 version = "0.4"
@@ -36,9 +41,10 @@ features = ["serde"]
 default = ["reqwest/default-tls"]
 json = []
 env = ["envy"]
-all = ["toml", "json", "env"]
+all = ["toml", "json", "env", "async"]
 rustls-tls = ["reqwest/rustls-tls"]
 nightly = []
+async = ["async-h1", "async-native-tls", "smol", "http-types", "async-mutex"]
 
 [dev-dependencies]
 tempfile = "3.0.3"

--- a/src/async/auth.rs
+++ b/src/async/auth.rs
@@ -1,0 +1,46 @@
+//! Authentication mechanisms for async client
+use async_mutex::Mutex;
+use std::cell::RefCell;
+
+use crate::{
+    entities::{account::Account, card::Card, context::Context, status::Status},
+    errors::{Error, Result},
+    requests::StatusesRequest,
+};
+use http_types::{Method, Request, Response};
+use hyper_old_types::header::{parsing, Link, RelationType};
+use serde::Serialize;
+use smol::{prelude::*, Async};
+use std::net::{TcpStream, ToSocketAddrs};
+use url::Url;
+
+/// strategies for authenticating mastodon requests need to implement this trait
+#[async_trait::async_trait]
+pub trait Authenticate {
+    async fn authenticate(&self, request: &mut Request) -> Result<()>;
+}
+
+/// The null-strategy, will only allow the client to call public API endpoints
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Unauthenticated;
+#[async_trait::async_trait]
+impl Authenticate for Unauthenticated {
+    async fn authenticate(&self, _: &mut Request) -> Result<()> {
+        Ok(())
+    }
+}
+
+/// Authenticates to the server via oauth
+#[derive(Debug, Clone, PartialEq)]
+pub struct OAuth {
+    client_id: String,
+    client_secret: String,
+    redirect: String,
+    token: String,
+}
+#[async_trait::async_trait]
+impl Authenticate for Mutex<RefCell<Option<OAuth>>> {
+    async fn authenticate(&self, _: &mut Request) -> Result<()> {
+        unimplemented!()
+    }
+}

--- a/src/async/client.rs
+++ b/src/async/client.rs
@@ -1,0 +1,52 @@
+use crate::{
+    entities::{account::Account, card::Card, context::Context, status::Status},
+    errors::{Error, Result},
+};
+use http_types::{Method, Request, Response};
+use hyper_old_types::header::{parsing, Link, RelationType};
+use smol::{prelude::*, Async};
+use std::net::{TcpStream, ToSocketAddrs};
+use url::Url;
+
+// taken pretty much verbatim from `smol`s example
+
+/// Sends a request and fetches the response.
+pub(super) async fn fetch(req: Request) -> Result<Response> {
+    // Figure out the host and the port.
+    let host = req
+        .url()
+        .host()
+        .ok_or_else(|| String::from("No host found"))?
+        .to_string();
+    let port = req
+        .url()
+        .port_or_known_default()
+        .ok_or_else(|| Error::Other(String::from("No port found")))?;
+
+    // Connect to the host.
+    let socket_addr = {
+        let host = host.clone();
+        smol::unblock(move || (host.as_str(), port).to_socket_addrs())
+            .await?
+            .next()
+            .ok_or_else(|| Error::Other(String::from("No socket addr")))?
+    };
+    let stream = Async::<TcpStream>::connect(socket_addr).await?;
+
+    // Send the request and wait for the response.
+    let resp = match req.url().scheme() {
+        "http" => async_h1::connect(stream, req).await?,
+        "https" => {
+            // In case of HTTPS, establish a secure TLS connection first.
+            let stream = async_native_tls::connect(&host, stream).await?;
+            async_h1::connect(stream, req).await?
+        },
+        scheme => return Err(Error::Other(format!("unsupported scheme '{}'", scheme))),
+    };
+    Ok(resp)
+}
+
+pub(super) async fn get(url: Url) -> Result<Response> {
+    let req = Request::new(Method::Get, url);
+    Ok(fetch(req).await?)
+}

--- a/src/async/mod.rs
+++ b/src/async/mod.rs
@@ -1,0 +1,263 @@
+//! Async Mastodon Client
+//!
+//! # Example
+//!
+//! ```rust,no_run
+//! use elefren::r#async::Client;
+//! use url::Url;
+//!
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! #   smol::block_on(async {
+//! let client = Client::new("https://mastodon.social")?;
+//!
+//! // iterate page-by-page
+//! // this API isn't ideal, but one day we'll get better
+//! // syntax support for iterating over streams and we can
+//! // do better
+//! let mut pages = client.public_timeline(None).await?;
+//! while let Some(statuses) = pages.next_page().await? {
+//!     for status in statuses {
+//!         println!("{:?}", status);
+//!     }
+//! }
+//! # Ok(())
+//! # })
+//! }
+//! ```
+#![allow(warnings)]
+#![allow(missing_docs)]
+use crate::{
+    entities::{
+        account::Account,
+        activity::Activity,
+        card::Card,
+        context::Context,
+        instance::Instance,
+        poll::Poll,
+        status::{Emoji, Status, Tag},
+    },
+    errors::{Error, Result},
+    requests::{DirectoryRequest, StatusesRequest},
+};
+use http_types::{Method, Request, Response};
+use std::fmt::Debug;
+use url::Url;
+
+pub use auth::Authenticate;
+use auth::{OAuth, Unauthenticated};
+pub use page::Page;
+
+mod auth;
+mod client;
+mod page;
+
+/// Async unauthenticated client
+#[derive(Debug)]
+pub struct Client<A: Debug + Authenticate> {
+    base_url: Url,
+    auth: A,
+}
+impl Client<Unauthenticated> {
+    pub fn new<S: AsRef<str>>(base_url: S) -> Result<Client<Unauthenticated>> {
+        let base_url = Url::parse(base_url.as_ref())?;
+        Ok(Client {
+            base_url,
+            auth: Unauthenticated,
+        })
+    }
+}
+impl<A: Debug + Authenticate> Client<A> {
+    async fn send(&self, mut req: Request) -> Result<Response> {
+        self.auth.authenticate(&mut req).await?;
+        Ok(client::fetch(req).await?)
+    }
+
+    /// GET /api/v1/timelines/public
+    pub async fn public_timeline<'a, 'client: 'a, I: Into<Option<StatusesRequest<'a>>>>(
+        &'client self,
+        opts: I,
+    ) -> Result<Page<'client, Status, A>> {
+        let mut url = self.base_url.join("api/v1/timelines/public")?;
+        if let Some(opts) = opts.into() {
+            let qs = opts.to_querystring()?;
+            url.set_query(Some(&qs[..]));
+        };
+        Ok(Page::new(Request::new(Method::Get, url), &self.auth))
+    }
+
+    /// GET /api/v1/timelines/tag/:tag
+    pub async fn hashtag_timeline<'a, 'client: 'a, I: Into<Option<StatusesRequest<'a>>>>(
+        &'client self,
+        tag: &str,
+        opts: I,
+    ) -> Result<Page<'client, Status, A>> {
+        let mut url = self
+            .base_url
+            .join(&format!("api/v1/timelines/tag/{}", tag))?;
+        if let Some(opts) = opts.into() {
+            let qs = opts.to_querystring()?;
+            url.set_query(Some(&qs[..]));
+        }
+        Ok(Page::new(Request::new(Method::Get, url), &self.auth))
+    }
+
+    /// GET /api/v1/statuses/:id
+    pub async fn status(&self, id: &str) -> Result<Status> {
+        let url = self.base_url.join(&format!("api/v1/statuses/{}", id))?;
+        let response = self.send(Request::new(Method::Get, url)).await?;
+        Ok(deserialize(response).await?)
+    }
+
+    /// GET /api/v1/statuses/:id/context
+    pub async fn context(&self, id: &str) -> Result<Context> {
+        let url = self
+            .base_url
+            .join(&format!("api/v1/statuses/{}/context", id))?;
+        let response = self.send(Request::new(Method::Get, url)).await?;
+        Ok(deserialize(response).await?)
+    }
+
+    /// GET /api/v1/statuses/:id/card
+    pub async fn card(&self, id: &str) -> Result<Card> {
+        let url = self
+            .base_url
+            .join(&format!("api/v1/statuses/{}/card", id))?;
+        let response = self.send(Request::new(Method::Get, url)).await?;
+        Ok(deserialize(response).await?)
+    }
+
+    /// GET /api/v1/statuses/:id/reblogged_by
+    pub async fn reblogged_by<'client>(
+        &'client self,
+        id: &str,
+    ) -> Result<Page<'client, Account, A>> {
+        let url = self
+            .base_url
+            .join(&format!("api/v1/statuses/{}/reblogged_by", id))?;
+        Ok(Page::new(Request::new(Method::Get, url), &self.auth))
+    }
+
+    /// GET /api/v1/statuses/:id/favourited_by
+    pub async fn favourited_by<'client>(
+        &'client self,
+        id: &str,
+    ) -> Result<Page<'client, Account, A>> {
+        let url = self
+            .base_url
+            .join(&format!("api/v1/statuses/{}/favourited_by", id))?;
+        Ok(Page::new(Request::new(Method::Get, url), &self.auth))
+    }
+
+    /// GET /api/v1/accounts/:id
+    pub async fn account(&self, id: &str) -> Result<Account> {
+        let url = self.base_url.join(&format!("api/v1/accounts/{}", id))?;
+        let response = self.send(Request::new(Method::Get, url)).await?;
+        Ok(deserialize(response).await?)
+    }
+
+    /// GET /api/v1/accounts/:id/statuses
+    pub async fn account_statuses<'a, 'client: 'a, I: Into<Option<StatusesRequest<'a>>>>(
+        &'client self,
+        id: &str,
+        request: I,
+    ) -> Result<Page<'client, Status, A>> {
+        let mut url = self
+            .base_url
+            .join(&format!("api/v1/accounts/{}/statuses", id))?;
+        if let Some(request) = request.into() {
+            let qs = request.to_querystring()?;
+            url.set_query(Some(&qs[..]));
+        }
+        Ok(Page::new(Request::new(Method::Get, url), &self.auth))
+    }
+
+    /// GET /api/v1/polls/:id
+    pub async fn poll(&self, id: &str) -> Result<Poll> {
+        let url = self.base_url.join(&format!("api/v1/polls/{}", id))?;
+        let response = self.send(Request::new(Method::Get, url)).await?;
+        Ok(deserialize(response).await?)
+    }
+
+    /// GET /api/v1/instance
+    pub async fn instance(&self) -> Result<Instance> {
+        let url = self.base_url.join("api/v1/instance")?;
+        let response = self.send(Request::new(Method::Get, url)).await?;
+        Ok(deserialize(response).await?)
+    }
+
+    /// GET /api/v1/instance/peers
+    pub async fn peers(&self) -> Result<Vec<String>> {
+        let url = self.base_url.join("api/v1/instance/peers")?;
+        let response = self.send(Request::new(Method::Get, url)).await?;
+        Ok(deserialize(response).await?)
+    }
+
+    /// GET /api/v1/instance/activity
+    pub async fn activity(&self) -> Result<Option<Vec<Activity>>> {
+        let url = self.base_url.join("api/v1/instance/activity")?;
+        let response = self.send(Request::new(Method::Get, url)).await?;
+        Ok(deserialize(response).await?)
+    }
+
+    /// GET /api/v1/custom_emojis
+    pub async fn custom_emojis(&self) -> Result<Vec<Emoji>> {
+        let url = self.base_url.join("api/v1/custom_emojis")?;
+        let response = self.send(Request::new(Method::Get, url)).await?;
+        Ok(deserialize(response).await?)
+    }
+
+    /// GET /api/v1/directory
+    pub async fn directory<'a, I: Into<Option<DirectoryRequest<'a>>>>(
+        &self,
+        opts: I,
+    ) -> Result<Vec<Account>> {
+        let mut url = self.base_url.join("api/v1/directory")?;
+        if let Some(opts) = opts.into() {
+            let qs = opts.to_querystring()?;
+            url.set_query(Some(&qs[..]));
+        }
+        let response = self.send(Request::new(Method::Get, url)).await?;
+        Ok(deserialize(response).await?)
+    }
+
+    /// GET /api/v1/trends
+    pub async fn trends<I: Into<Option<usize>>>(&self, limit: I) -> Result<Vec<Tag>> {
+        let mut url = self.base_url.join("api/v1/trends")?;
+        if let Some(limit) = limit.into() {
+            url.set_query(Some(&format!("?limit={}", limit)));
+        }
+        let response = self.send(Request::new(Method::Get, url)).await?;
+        Ok(deserialize(response).await?)
+    }
+}
+
+async fn deserialize<T: serde::de::DeserializeOwned>(mut response: Response) -> Result<T> {
+    let status = response.status();
+    if status.is_client_error() {
+        // TODO
+        // return Err(Error::Client(status));
+        return Err(Error::Other(String::from("4xx status code")));
+    } else if status.is_server_error() {
+        // TODO
+        // return Err(Error::Server(status)) // TODO
+        return Err(Error::Other(String::from("5xx status code")));
+    } else if status.is_redirection() || status.is_informational() {
+        return Err(Error::Other(String::from("3xx or 1xx status code")));
+    }
+    let bytes = response.body_bytes().await?;
+    Ok(match serde_json::from_slice::<T>(&bytes) {
+        Ok(t) => {
+            log::debug!("{}", String::from_utf8_lossy(&bytes));
+            t
+        },
+        Err(e) => {
+            log::error!("{}", String::from_utf8_lossy(&bytes));
+            let err = if let Ok(error) = serde_json::from_slice(&bytes) {
+                Error::Api(error)
+            } else {
+                e.into()
+            };
+            return Err(err);
+        },
+    })
+}

--- a/src/async/page.rs
+++ b/src/async/page.rs
@@ -1,0 +1,95 @@
+use super::{client, deserialize, Authenticate};
+use crate::{
+    entities::{account::Account, card::Card, context::Context, status::Status},
+    errors::{Error, Result},
+};
+use http_types::{Method, Request, Response};
+use hyper_old_types::header::{parsing, Link, RelationType};
+use smol::{prelude::*, Async};
+use std::{
+    fmt::Debug,
+    net::{TcpStream, ToSocketAddrs},
+};
+use url::Url;
+
+// link header name
+const LINK: &str = "link";
+
+#[derive(Debug)]
+pub struct Page<'client, T, A: Authenticate + Debug + 'client> {
+    next: Option<Request>,
+    prev: Option<Request>,
+    auth: &'client A,
+    _marker: std::marker::PhantomData<T>,
+}
+impl<'client, T: serde::de::DeserializeOwned, A: Authenticate + Debug + 'client>
+    Page<'client, T, A>
+{
+    pub fn new(next: Request, auth: &'client A) -> Page<'client, T, A> {
+        Page {
+            next: Some(next),
+            prev: None,
+            auth,
+            _marker: std::marker::PhantomData,
+        }
+    }
+
+    pub async fn next_page(&mut self) -> Result<Option<Vec<T>>> {
+        let mut req = if let Some(next) = self.next.take() {
+            next
+        } else {
+            return Ok(None);
+        };
+        Ok(self.send(req).await?)
+    }
+
+    pub async fn prev_page(&mut self) -> Result<Option<Vec<T>>> {
+        let req = if let Some(prev) = self.prev.take() {
+            prev
+        } else {
+            return Ok(None);
+        };
+        Ok(self.send(req).await?)
+    }
+
+    async fn send(&mut self, mut req: Request) -> Result<Option<Vec<T>>> {
+        self.auth.authenticate(&mut req).await?;
+        log::trace!("Request: {:?}", req);
+        let response = client::fetch(req).await?;
+        log::trace!("Response: {:?}", response);
+        self.fill_links_from_resp(&response)?;
+        let items = deserialize(response).await?;
+        Ok(items)
+    }
+
+    fn fill_links_from_resp(&mut self, response: &Response) -> Result<()> {
+        let (prev, next) = get_links(&response)?;
+        self.prev = prev.map(|url| Request::new(Method::Get, url));
+        self.next = next.map(|url| Request::new(Method::Get, url));
+        Ok(())
+    }
+}
+
+fn get_links(response: &Response) -> Result<(Option<Url>, Option<Url>)> {
+    let mut prev = None;
+    let mut next = None;
+
+    if let Some(link_header) = response.header(LINK) {
+        let link_header = link_header.as_str();
+        let link_header = link_header.as_bytes();
+        let link_header: Link = parsing::from_raw_str(&link_header)?;
+        for value in link_header.values() {
+            if let Some(relations) = value.rel() {
+                if relations.contains(&RelationType::Next) {
+                    next = Some(Url::parse(value.link())?);
+                }
+
+                if relations.contains(&RelationType::Prev) {
+                    prev = Some(Url::parse(value.link())?);
+                }
+            }
+        }
+    }
+
+    Ok((prev, next))
+}

--- a/src/entities/activity.rs
+++ b/src/entities/activity.rs
@@ -1,0 +1,14 @@
+use serde::{Deserialize, Serialize};
+
+/// Represents a weekly bucket of instance activity.
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct Activity {
+    /// Midnight at the first day of the week.
+    pub week: String,
+    /// Statuses created since the week began.
+    pub statuses: String,
+    /// User logins since the week began.
+    pub logins: String,
+    /// User registrations since the week began.
+    pub registrations: String,
+}

--- a/src/entities/announcement.rs
+++ b/src/entities/announcement.rs
@@ -1,0 +1,50 @@
+use serde::{Deserialize, Serialize};
+
+/// Custom emoji fields for AnnouncementReaction
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct AnnouncementReactionCustomEmoji {
+    /// A link to the custom emoji.
+    pub url: String,
+    /// A link to a non-animated version of the custom emoji.
+    pub static_url: String,
+}
+
+/// Represents an emoji reaction to an Announcement.
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct AnnouncementReaction {
+    /// The emoji used for the reaction. Either a unicode emoji, or a custom emoji's shortcode.
+    pub name: String,
+    /// The total number of users who have added this reaction.
+    pub count: u64,
+    /// Whether the authorized user has added this reaction to the announcement.
+    pub me: bool,
+    #[serde(flatten)]
+    pub emoji: Option<AnnouncementReactionCustomEmoji>,
+}
+
+/// Represents an announcement set by an administrator.
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct Announcement {
+    /// The announcement id.
+    id: String,
+    /// The content of the announcement.
+    text: String,
+    /// Whether the announcement is currently active.
+    published: bool,
+    /// Whether the announcement has a start/end time.
+    all_day: bool,
+    /// When the announcement was created.
+    created_at: String, // Datetime
+    /// When the announcement was last updated.
+    updated_at: String, // Datetime
+    /// Whether the announcement has been read by the user.
+    read: bool,
+    /// Emoji reactions attached to the announcement.
+    reactions: Vec<AnnouncementReaction>,
+    /// When the future announcement was scheduled.
+    scheduled_at: Option<String>, // Datetime
+    /// When the future announcement will start.
+    starts_at: Option<String>, // Datetime
+    /// When the future announcement will end.
+    ends_at: Option<String>, // Datetime
+}

--- a/src/entities/mod.rs
+++ b/src/entities/mod.rs
@@ -2,6 +2,8 @@ use serde::Deserialize;
 
 /// Data structures for ser/de of account-related resources
 pub mod account;
+/// Data structures for ser/de of activity-related resources
+pub mod activity;
 /// Data structures for ser/de of attachment-related resources
 pub mod attachment;
 /// Data structures for ser/de of card-related resources
@@ -21,6 +23,8 @@ pub mod list;
 pub mod mention;
 /// Data structures for ser/de of notification-related resources
 pub mod notification;
+/// Data structures for ser/de of poll resources
+pub mod poll;
 /// Data structures for ser/de of push-subscription-related resources
 pub mod push;
 /// Data structures for ser/de of relationship-related resources

--- a/src/entities/poll.rs
+++ b/src/entities/poll.rs
@@ -1,0 +1,37 @@
+use crate::entities::status::Emoji;
+use serde::{Deserialize, Serialize};
+
+/// Represents a poll attached to a status.
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct Poll {
+    /// The ID of the poll in the database.
+    pub id: String,
+    /// When the poll ends.
+    pub expires_at: String, // Datetime??
+    /// Is the poll currently expired?
+    pub expired: bool,
+    /// Does the poll allow multiple-choice answers?
+    pub multiple: bool,
+    /// How many votes have been received.
+    pub votes_count: u64,
+    /// How many unique accounts have voted on a multiple-choice poll.
+    pub voters_count: Option<u64>,
+    /// When called with a user token, has the authorized user voted?
+    pub voted: Option<bool>,
+    /// When called with a user token, which options has the authorized user
+    /// chosen? Contains an array of index values for options
+    pub own_votes: Option<Vec<u64>>,
+    /// Possible answers for the poll.
+    pub options: Vec<PollOption>,
+    /// Custom emoji to be used for rendering poll options.
+    pub emojis: Vec<Emoji>,
+}
+
+/// Possible answers for the poll.
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct PollOption {
+    /// The text value of the poll option.
+    pub title: String,
+    /// The number of received votes for this option.
+    pub votes_count: Option<u64>,
+}

--- a/src/entities/status.rs
+++ b/src/entities/status.rs
@@ -1,9 +1,15 @@
 //! Module containing all info relating to a status.
 
 use super::prelude::*;
-use crate::{entities::card::Card, status_builder::Visibility};
+use crate::{
+    entities::{
+        card::Card,
+        poll::Poll,
+    },
+    status_builder::Visibility
+};
 use chrono::prelude::*;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 /// A status from the instance.
 #[derive(Debug, Clone, Deserialize, PartialEq)]
@@ -12,10 +18,38 @@ pub struct Status {
     pub id: String,
     /// A Fediverse-unique resource ID.
     pub uri: String,
-    /// URL to the status page (can be remote)
-    pub url: Option<String>,
+    /// The time the status was created.
+    pub created_at: DateTime<Utc>,
     /// The Account which posted the status.
     pub account: Account,
+    /// Body of the status; this will contain HTML
+    /// (remote HTML already sanitized)
+    pub content: String,
+    /// The visibilty of the status.
+    pub visibility: Visibility,
+    /// Whether media attachments should be hidden by default.
+    pub sensitive: bool,
+    /// If not empty, warning text that should be displayed before the actual
+    /// content.
+    pub spoiler_text: String,
+    /// An array of attachments.
+    pub media_attachments: Vec<Attachment>,
+    /// Name of application used to post status.
+    pub application: Option<Application>,
+    /// An array of mentions.
+    pub mentions: Vec<Mention>,
+    /// An array of tags.
+    pub tags: Vec<Tag>,
+    /// An array of Emoji
+    pub emojis: Vec<Emoji>,
+    /// The number of reblogs for the status.
+    pub reblogs_count: u64,
+    /// The number of favourites for the status.
+    pub favourites_count: u64,
+    /// The numbef or replies to this status.
+    pub replies_count: Option<u64>,
+    /// URL to the status page (can be remote)
+    pub url: Option<String>,
     /// The ID of the status this status is replying to, if the status is
     /// a reply.
     pub in_reply_to_id: Option<String>,
@@ -24,42 +58,22 @@ pub struct Status {
     pub in_reply_to_account_id: Option<String>,
     /// If this status is a reblogged Status of another User.
     pub reblog: Option<Box<Status>>,
-    /// Body of the status; this will contain HTML
-    /// (remote HTML already sanitized)
-    pub content: String,
-    /// The time the status was created.
-    pub created_at: DateTime<Utc>,
-    /// An array of Emoji
-    pub emojis: Vec<Emoji>,
-    /// The numbef or replies to this status.
-    pub replies_count: Option<u64>,
-    /// The number of reblogs for the status.
-    pub reblogs_count: u64,
-    /// The number of favourites for the status.
-    pub favourites_count: u64,
-    /// Whether the application client has reblogged the status.
-    pub reblogged: Option<bool>,
-    /// Whether the application client has favourited the status.
-    pub favourited: Option<bool>,
-    /// Whether media attachments should be hidden by default.
-    pub sensitive: bool,
-    /// If not empty, warning text that should be displayed before the actual
-    /// content.
-    pub spoiler_text: String,
-    /// The visibilty of the status.
-    pub visibility: Visibility,
-    /// An array of attachments.
-    pub media_attachments: Vec<Attachment>,
-    /// An array of mentions.
-    pub mentions: Vec<Mention>,
-    /// An array of tags.
-    pub tags: Vec<Tag>,
+    /// The poll attached to the status.
+    pub poll: Option<Poll>,
     /// The associated card
     pub card: Option<Card>,
-    /// Name of application used to post status.
-    pub application: Option<Application>,
     /// The detected language for the status, if detected.
     pub language: Option<String>,
+    /// Plain-text source of a status. Returned instead of content when status is deleted, so the user may redraft from the source text without the client having to reverse-engineer the original text from the HTML content.
+    pub text: Option<String>,
+    /// Whether the application client has favourited the status.
+    pub favourited: Option<bool>,
+    /// Whether the application client has reblogged the status.
+    pub reblogged: Option<bool>,
+    /// Have you muted notifications for this status's conversation?
+    pub muted: Option<bool>,
+    /// Have you bookmarked this status?
+    pub bookmarked: Option<bool>,
     /// Whether this is the pinned status for the account that posted it.
     pub pinned: Option<bool>,
 }
@@ -78,7 +92,7 @@ pub struct Mention {
 }
 
 /// Struct representing an emoji within text.
-#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 pub struct Emoji {
     /// The shortcode of the emoji
     pub shortcode: String,
@@ -95,6 +109,19 @@ pub struct Tag {
     pub name: String,
     /// The URL of the hashtag.
     pub url: String,
+    /// Usage statistics for given days.
+    pub history: Option<Vec<History>>,
+}
+
+/// Represents daily usage history of a hashtag.
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+pub struct History {
+    /// UNIX timestamp on midnight of the given day.
+    day: String,
+    /// the counted usage of the tag within that day.
+    uses: String,
+    /// the total of accounts using the tag within that day.
+    accounts: String,
 }
 
 /// Application details.

--- a/src/entities/status.rs
+++ b/src/entities/status.rs
@@ -2,11 +2,8 @@
 
 use super::prelude::*;
 use crate::{
-    entities::{
-        card::Card,
-        poll::Poll,
-    },
-    status_builder::Visibility
+    entities::{card::Card, poll::Poll},
+    status_builder::Visibility,
 };
 use chrono::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -64,7 +61,10 @@ pub struct Status {
     pub card: Option<Card>,
     /// The detected language for the status, if detected.
     pub language: Option<String>,
-    /// Plain-text source of a status. Returned instead of content when status is deleted, so the user may redraft from the source text without the client having to reverse-engineer the original text from the HTML content.
+    /// Plain-text source of a status. Returned instead of content when status
+    /// is deleted, so the user may redraft from the source text without the
+    /// client having to reverse-engineer the original text from the HTML
+    /// content.
     pub text: Option<String>,
     /// Whether the application client has favourited the status.
     pub favourited: Option<bool>,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -5,8 +5,12 @@ use std::{error, fmt, io::Error as IoError};
 use ::toml::de::Error as TomlDeError;
 #[cfg(feature = "toml")]
 use ::toml::ser::Error as TomlSerError;
+#[cfg(feature = "async")]
+use async_native_tls::Error as TlsError;
 #[cfg(feature = "env")]
 use envy::Error as EnvyError;
+#[cfg(feature = "async")]
+use http_types::Error as HttpTypesError;
 use hyper_old_types::Error as HeaderParseError;
 use reqwest::{header::ToStrError as HeaderStrError, Error as HttpError, StatusCode};
 use serde_json::Error as SerdeError;
@@ -64,6 +68,12 @@ pub enum Error {
     SerdeQs(SerdeQsError),
     /// WebSocket error
     WebSocket(WebSocketError),
+    #[cfg(feature = "async")]
+    /// http-types error
+    HttpTypes(HttpTypesError),
+    #[cfg(feature = "async")]
+    /// TLS error
+    Tls(TlsError),
     /// Other errors
     Other(String),
 }
@@ -99,6 +109,10 @@ impl error::Error for Error {
             Error::ClientSecretRequired => return None,
             Error::AccessTokenRequired => return None,
             Error::MissingField(_) => return None,
+            #[cfg(feature = "async")]
+            Error::HttpTypes(..) => return None,
+            #[cfg(feature = "async")]
+            Error::Tls(ref e) => e,
             Error::Other(..) => return None,
         })
     }
@@ -149,6 +163,8 @@ from! {
     #[cfg(feature = "env")] EnvyError, Envy,
     SerdeQsError, SerdeQs,
     WebSocketError, WebSocket,
+    #[cfg(feature = "async")] HttpTypesError, HttpTypes,
+    #[cfg(feature = "async")] TlsError, Tls,
     String, Other,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,6 +98,9 @@ pub use crate::{
 
 /// Registering your App
 pub mod apps;
+/// Async client
+#[cfg(feature = "async")]
+pub mod r#async;
 /// Contains the struct that holds the client auth data
 pub mod data;
 /// Entities returned from the API
@@ -272,7 +275,7 @@ impl MastodonClient for Mastodon {
         deserialise_blocking(response)
     }
 
-    fn update_credentials(&self, builder: &mut UpdateCredsRequest) -> Result<Account> {
+    fn update_credentials(&self, builder: UpdateCredsRequest) -> Result<Account> {
         let changes = builder.build()?;
         let url = self.route("/api/v1/accounts/update_credentials");
         let response = self.send_blocking(self.client.patch(&url).json(&changes))?;
@@ -348,8 +351,8 @@ impl MastodonClient for Mastodon {
     /// #   token: "".into(),
     /// # };
     /// let client = Mastodon::from(data);
-    /// let mut request = StatusesRequest::new();
-    /// request.only_media();
+    /// let request = StatusesRequest::new()
+    ///     .only_media();
     /// let statuses = client.statuses("user-id", request)?;
     /// # Ok(())
     /// # }

--- a/src/mastodon_client.rs
+++ b/src/mastodon_client.rs
@@ -192,7 +192,7 @@ pub trait MastodonClient {
         unimplemented!("This method was not implemented");
     }
     /// PATCH /api/v1/accounts/update_credentials
-    fn update_credentials(&self, builder: &mut UpdateCredsRequest) -> Result<Account> {
+    fn update_credentials(&self, builder: UpdateCredsRequest) -> Result<Account> {
         unimplemented!("This method was not implemented");
     }
     /// POST /api/v1/statuses

--- a/src/requests/directory.rs
+++ b/src/requests/directory.rs
@@ -75,6 +75,6 @@ impl<'a> DirectoryRequest<'a> {
     /// );
     /// ```
     pub fn to_querystring(&self) -> Result<String, Error> {
-        Ok(format!("{}", serde_qs::to_string(&self)?))
+        Ok(serde_qs::to_string(&self)?)
     }
 }

--- a/src/requests/directory.rs
+++ b/src/requests/directory.rs
@@ -1,0 +1,80 @@
+use crate::errors::Error;
+use serde::Serialize;
+use std::borrow::Cow;
+
+mod bool_qs_serialize {
+    use serde::Serializer;
+
+    pub fn is_false(b: &bool) -> bool {
+        !*b
+    }
+
+    pub fn serialize<S: Serializer>(b: &bool, s: S) -> Result<S::Ok, S::Error> {
+        if *b {
+            s.serialize_i64(1)
+        } else {
+            s.serialize_i64(0)
+        }
+    }
+}
+
+/// Represents the options for the directory request
+#[derive(Debug, Clone, Default, PartialEq, Serialize)]
+pub struct DirectoryRequest<'a> {
+    offset: Option<usize>,
+    limit: Option<usize>,
+    order: Option<Cow<'a, str>>, // TODO enum
+    #[serde(skip_serializing_if = "bool_qs_serialize::is_false")]
+    #[serde(serialize_with = "bool_qs_serialize::serialize")]
+    local: bool,
+}
+impl<'a> DirectoryRequest<'a> {
+    /// make a new DirectoryRequest builder
+    pub fn new() -> Self {
+        DirectoryRequest::default()
+    }
+
+    /// sets the offset
+    pub fn offset(mut self, offset: usize) -> Self {
+        self.offset = Some(offset);
+        self
+    }
+
+    /// sets the limit
+    pub fn limit(mut self, limit: usize) -> Self {
+        self.limit = Some(limit);
+        self
+    }
+
+    /// sets the order
+    pub fn order<I: Into<Cow<'a, str>>>(mut self, order: I) -> Self {
+        self.order = Some(order.into());
+        self
+    }
+
+    /// sets the local
+    pub fn local(mut self) -> Self {
+        self.local = true;
+        self
+    }
+
+    /// Turns this builder into a querystring
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # extern crate elefren;
+    /// # use elefren::requests::DirectoryRequest;
+    /// let request = DirectoryRequest::new();
+    /// assert_eq!(
+    ///     &request
+    ///         .limit(10)
+    ///         .to_querystring()
+    ///         .expect("Couldn't serialize qs"),
+    ///     "limit=10"
+    /// );
+    /// ```
+    pub fn to_querystring(&self) -> Result<String, Error> {
+        Ok(format!("{}", serde_qs::to_string(&self)?))
+    }
+}

--- a/src/requests/filter.rs
+++ b/src/requests/filter.rs
@@ -126,7 +126,8 @@ mod tests {
 
     #[test]
     fn test_expires_in() {
-        let request = AddFilterRequest::new("foo", FilterContext::Home).expires_in(Duration::from_secs(300));
+        let request =
+            AddFilterRequest::new("foo", FilterContext::Home).expires_in(Duration::from_secs(300));
         assert_eq!(
             request,
             AddFilterRequest {
@@ -141,7 +142,8 @@ mod tests {
 
     #[test]
     fn test_serialize_request() {
-        let request = AddFilterRequest::new("foo", FilterContext::Home).expires_in(Duration::from_secs(300));
+        let request =
+            AddFilterRequest::new("foo", FilterContext::Home).expires_in(Duration::from_secs(300));
         let ser = serde_json::to_string(&request).expect("Couldn't serialize");
         assert_eq!(
             ser,

--- a/src/requests/filter.rs
+++ b/src/requests/filter.rs
@@ -38,19 +38,19 @@ impl AddFilterRequest {
     }
 
     /// Set `irreversible` to `true`
-    pub fn irreversible(&mut self) -> &mut Self {
+    pub fn irreversible(mut self) -> Self {
         self.irreversible = Some(true);
         self
     }
 
     /// Set `whole_word` to `true`
-    pub fn whole_word(&mut self) -> &mut Self {
+    pub fn whole_word(mut self) -> Self {
         self.whole_word = Some(true);
         self
     }
 
     /// Set `expires_in` to a duration
-    pub fn expires_in(&mut self, d: Duration) -> &mut Self {
+    pub fn expires_in(mut self, d: Duration) -> Self {
         self.expires_in = Some(d);
         self
     }
@@ -96,8 +96,7 @@ mod tests {
 
     #[test]
     fn test_irreversible() {
-        let mut request = AddFilterRequest::new("foo", FilterContext::Home);
-        request.irreversible();
+        let request = AddFilterRequest::new("foo", FilterContext::Home).irreversible();
         assert_eq!(
             request,
             AddFilterRequest {
@@ -112,8 +111,7 @@ mod tests {
 
     #[test]
     fn test_whole_word() {
-        let mut request = AddFilterRequest::new("foo", FilterContext::Home);
-        request.whole_word();
+        let request = AddFilterRequest::new("foo", FilterContext::Home).whole_word();
         assert_eq!(
             request,
             AddFilterRequest {
@@ -128,8 +126,7 @@ mod tests {
 
     #[test]
     fn test_expires_in() {
-        let mut request = AddFilterRequest::new("foo", FilterContext::Home);
-        request.expires_in(Duration::from_secs(300));
+        let request = AddFilterRequest::new("foo", FilterContext::Home).expires_in(Duration::from_secs(300));
         assert_eq!(
             request,
             AddFilterRequest {
@@ -144,8 +141,7 @@ mod tests {
 
     #[test]
     fn test_serialize_request() {
-        let mut request = AddFilterRequest::new("foo", FilterContext::Home);
-        request.expires_in(Duration::from_secs(300));
+        let request = AddFilterRequest::new("foo", FilterContext::Home).expires_in(Duration::from_secs(300));
         let ser = serde_json::to_string(&request).expect("Couldn't serialize");
         assert_eq!(
             ser,

--- a/src/requests/mod.rs
+++ b/src/requests/mod.rs
@@ -1,3 +1,5 @@
+/// Data structure for the MastodonClient::directory method
+pub use self::directory::DirectoryRequest;
 /// Data structure for the MastodonClient::add_filter method
 pub use self::filter::AddFilterRequest;
 /// Data structure for the MastodonClient::add_push_subscription method
@@ -7,6 +9,7 @@ pub use self::statuses::StatusesRequest;
 /// Data structure for the MastodonClient::update_credentials method
 pub use self::update_credentials::UpdateCredsRequest;
 
+mod directory;
 mod filter;
 mod push;
 mod statuses;

--- a/src/requests/push.rs
+++ b/src/requests/push.rs
@@ -59,8 +59,8 @@ impl Keys {
 /// let client = Mastodon::from(data);
 ///
 /// let keys = Keys::new("stahesuahoei293ise===", "tasecoa,nmeozka==");
-/// let mut request = AddPushRequest::new("http://example.com/push/endpoint", &keys);
-/// request.follow().reblog();
+/// let mut request = AddPushRequest::new("http://example.com/push/endpoint", &keys)
+///     .follow().reblog();
 ///
 /// client.add_push_subscription(&request)?;
 /// #   Ok(())
@@ -111,7 +111,7 @@ impl AddPushRequest {
     /// let mut request = AddPushRequest::new(push_endpoint, &keys);
     /// request.follow();
     /// ```
-    pub fn follow(&mut self) -> &mut Self {
+    pub fn follow(mut self) -> Self {
         self.follow = Some(true);
         self
     }
@@ -127,7 +127,7 @@ impl AddPushRequest {
     /// let mut request = AddPushRequest::new(push_endpoint, &keys);
     /// request.favourite();
     /// ```
-    pub fn favourite(&mut self) -> &mut Self {
+    pub fn favourite(mut self) -> Self {
         self.favourite = Some(true);
         self
     }
@@ -143,7 +143,7 @@ impl AddPushRequest {
     /// let mut request = AddPushRequest::new(push_endpoint, &keys);
     /// request.reblog();
     /// ```
-    pub fn reblog(&mut self) -> &mut Self {
+    pub fn reblog(mut self) -> Self {
         self.reblog = Some(true);
         self
     }
@@ -159,7 +159,7 @@ impl AddPushRequest {
     /// let mut request = AddPushRequest::new(push_endpoint, &keys);
     /// request.mention();
     /// ```
-    pub fn mention(&mut self) -> &mut Self {
+    pub fn mention(mut self) -> Self {
         self.mention = Some(true);
         self
     }
@@ -232,8 +232,8 @@ impl AddPushRequest {
 ///
 /// let client = Mastodon::from(data);
 ///
-/// let mut request = UpdatePushRequest::new("foobar");
-/// request.follow(true).reblog(true);
+/// let request = UpdatePushRequest::new("foobar")
+///     .follow(true).reblog(true);
 ///
 /// client.update_push_data(&request)?;
 /// #   Ok(())
@@ -274,7 +274,7 @@ impl UpdatePushRequest {
     /// let mut request = UpdatePushRequest::new("foobar");
     /// request.follow(true);
     /// ```
-    pub fn follow(&mut self, follow: bool) -> &mut Self {
+    pub fn follow(mut self, follow: bool) -> Self {
         self.follow = Some(follow);
         self
     }
@@ -288,7 +288,7 @@ impl UpdatePushRequest {
     /// let mut request = UpdatePushRequest::new("foobar");
     /// request.favourite(true);
     /// ```
-    pub fn favourite(&mut self, favourite: bool) -> &mut Self {
+    pub fn favourite(mut self, favourite: bool) -> Self {
         self.favourite = Some(favourite);
         self
     }
@@ -302,7 +302,7 @@ impl UpdatePushRequest {
     /// let mut request = UpdatePushRequest::new("foobar");
     /// request.reblog(true);
     /// ```
-    pub fn reblog(&mut self, reblog: bool) -> &mut Self {
+    pub fn reblog(mut self, reblog: bool) -> Self {
         self.reblog = Some(reblog);
         self
     }
@@ -316,7 +316,7 @@ impl UpdatePushRequest {
     /// let mut request = UpdatePushRequest::new("foobar");
     /// request.mention(true);
     /// ```
-    pub fn mention(&mut self, mention: bool) -> &mut Self {
+    pub fn mention(mut self, mention: bool) -> Self {
         self.mention = Some(mention);
         self
     }
@@ -400,8 +400,7 @@ mod tests {
     fn test_add_push_request_follow() {
         let endpoint = "https://example.com/push/endpoint";
         let keys = Keys::new("anetohias===", "oeatssah=");
-        let mut req = AddPushRequest::new(endpoint, &keys);
-        req.follow();
+        let req = AddPushRequest::new(endpoint, &keys).follow();
         assert_eq!(
             req,
             AddPushRequest {
@@ -420,8 +419,7 @@ mod tests {
     fn test_add_push_request_favourite() {
         let endpoint = "https://example.com/push/endpoint";
         let keys = Keys::new("anetohias===", "oeatssah=");
-        let mut req = AddPushRequest::new(endpoint, &keys);
-        req.favourite();
+        let req = AddPushRequest::new(endpoint, &keys).favourite();
         assert_eq!(
             req,
             AddPushRequest {
@@ -439,8 +437,7 @@ mod tests {
     fn test_add_push_request_reblog() {
         let endpoint = "https://example.com/push/endpoint";
         let keys = Keys::new("anetohias===", "oeatssah=");
-        let mut req = AddPushRequest::new(endpoint, &keys);
-        req.reblog();
+        let req = AddPushRequest::new(endpoint, &keys).reblog();
         assert_eq!(
             req,
             AddPushRequest {
@@ -458,8 +455,7 @@ mod tests {
     fn test_add_push_request_mention() {
         let endpoint = "https://example.com/push/endpoint";
         let keys = Keys::new("anetohias===", "oeatssah=");
-        let mut req = AddPushRequest::new(endpoint, &keys);
-        req.mention();
+        let req = AddPushRequest::new(endpoint, &keys).mention();
         assert_eq!(
             req,
             AddPushRequest {
@@ -498,8 +494,7 @@ mod tests {
     fn test_add_push_request_build() {
         let endpoint = "https://example.com/push/endpoint";
         let keys = Keys::new("anetohias===", "oeatssah=");
-        let mut req = AddPushRequest::new(endpoint, &keys);
-        req.follow().reblog();
+        let req = AddPushRequest::new(endpoint, &keys).follow().reblog();
         let form = req.build().expect("Couldn't build form");
         assert_eq!(
             form,
@@ -540,8 +535,7 @@ mod tests {
 
     #[test]
     fn test_update_push_request_follow() {
-        let mut req = UpdatePushRequest::new("some-id");
-        req.follow(true);
+        let req = UpdatePushRequest::new("some-id").follow(true);
         assert_eq!(
             req,
             UpdatePushRequest {
@@ -555,8 +549,7 @@ mod tests {
     }
     #[test]
     fn test_update_push_request_favourite() {
-        let mut req = UpdatePushRequest::new("some-id");
-        req.favourite(true);
+        let req = UpdatePushRequest::new("some-id").favourite(true);
         assert_eq!(
             req,
             UpdatePushRequest {
@@ -570,8 +563,7 @@ mod tests {
     }
     #[test]
     fn test_update_push_request_reblog() {
-        let mut req = UpdatePushRequest::new("some-id");
-        req.reblog(true);
+        let req = UpdatePushRequest::new("some-id").reblog(true);
         assert_eq!(
             req,
             UpdatePushRequest {
@@ -585,8 +577,7 @@ mod tests {
     }
     #[test]
     fn test_update_push_request_mention() {
-        let mut req = UpdatePushRequest::new("some-id");
-        req.mention(true);
+        let req = UpdatePushRequest::new("some-id").mention(true);
         assert_eq!(
             req,
             UpdatePushRequest {
@@ -615,8 +606,7 @@ mod tests {
 
     #[test]
     fn test_update_push_request_build() {
-        let mut req = UpdatePushRequest::new("some-id");
-        req.favourite(false);
+        let req = UpdatePushRequest::new("some-id").favourite(false);
         let form = req.build();
         assert_eq!(
             form,

--- a/src/requests/statuses.rs
+++ b/src/requests/statuses.rs
@@ -412,230 +412,143 @@ mod tests {
     #[test]
     fn test_to_querystring() {
         macro_rules! qs_test {
-            (|$r:ident| $b:block, $expected:expr) => {
-                {
-                    let $r = StatusesRequest::new();
-                    let $r = $b;
-                    let qs = $r.to_querystring().expect("Failed to serialize querystring");
-                    assert_eq!(&qs, $expected);
-                }
-            }
+            (| $r:ident | $b:block, $expected:expr) => {{
+                let $r = StatusesRequest::new();
+                let $r = $b;
+                let qs = $r
+                    .to_querystring()
+                    .expect("Failed to serialize querystring");
+                assert_eq!(&qs, $expected);
+            }};
         }
 
+        qs_test!(|request| { request.only_media() }, "?only_media=1");
         qs_test!(
-            |request| {
-                request.only_media()
-            },
-            "?only_media=1"
-        );
-        qs_test!(
-            |request| {
-                request.exclude_replies()
-            },
+            |request| { request.exclude_replies() },
             "?exclude_replies=1"
         );
+        qs_test!(|request| { request.pinned() }, "?pinned=1");
+        qs_test!(|request| { request.max_id("foo") }, "?max_id=foo");
+        qs_test!(|request| { request.since_id("foo") }, "?since_id=foo");
+        qs_test!(|request| { request.limit(42) }, "?limit=42");
         qs_test!(
-            |request| {
-                request.pinned()
-            },
-            "?pinned=1"
-        );
-        qs_test!(
-            |request| {
-                request.max_id("foo")
-            },
-            "?max_id=foo"
-        );
-        qs_test!(
-            |request| {
-                request.since_id("foo")
-            },
-            "?since_id=foo"
-        );
-        qs_test!(
-            |request| {
-                request.limit(42)
-            },
-            "?limit=42"
-        );
-        qs_test!(
-            |request| {
-                request.only_media().exclude_replies()
-            },
+            |request| { request.only_media().exclude_replies() },
             "?only_media=1&exclude_replies=1"
         );
         qs_test!(
-            |request| {
-                request.only_media().pinned()
-            },
+            |request| { request.only_media().pinned() },
             "?only_media=1&pinned=1"
         );
         qs_test!(
-            |request| {
-                request.only_media().max_id("foo")
-            },
+            |request| { request.only_media().max_id("foo") },
             "?only_media=1&max_id=foo"
         );
         qs_test!(
-            |request| {
-                request.only_media().since_id("foo")
-            },
+            |request| { request.only_media().since_id("foo") },
             "?only_media=1&since_id=foo"
         );
         qs_test!(
-            |request| {
-                request.only_media().limit(42)
-            },
+            |request| { request.only_media().limit(42) },
             "?only_media=1&limit=42"
         );
         qs_test!(
-            |request| {
-                request.exclude_replies().only_media()
-            },
+            |request| { request.exclude_replies().only_media() },
             "?only_media=1&exclude_replies=1"
         );
         qs_test!(
-            |request| {
-                request.exclude_replies().pinned()
-            },
+            |request| { request.exclude_replies().pinned() },
             "?exclude_replies=1&pinned=1"
         );
         qs_test!(
-            |request| {
-                request.exclude_replies().max_id("foo")
-            },
+            |request| { request.exclude_replies().max_id("foo") },
             "?exclude_replies=1&max_id=foo"
         );
         qs_test!(
-            |request| {
-                request.exclude_replies().since_id("foo")
-            },
+            |request| { request.exclude_replies().since_id("foo") },
             "?exclude_replies=1&since_id=foo"
         );
         qs_test!(
-            |request| {
-                request.exclude_replies().limit(42)
-            },
+            |request| { request.exclude_replies().limit(42) },
             "?exclude_replies=1&limit=42"
         );
         qs_test!(
-            |request| {
-                request.pinned().only_media()
-            },
+            |request| { request.pinned().only_media() },
             "?only_media=1&pinned=1"
         );
         qs_test!(
-            |request| {
-                request.pinned().exclude_replies()
-            },
+            |request| { request.pinned().exclude_replies() },
             "?exclude_replies=1&pinned=1"
         );
         qs_test!(
-            |request| {
-                request.pinned().max_id("foo")
-            },
+            |request| { request.pinned().max_id("foo") },
             "?pinned=1&max_id=foo"
         );
         qs_test!(
-            |request| {
-                request.pinned().since_id("foo")
-            },
+            |request| { request.pinned().since_id("foo") },
             "?pinned=1&since_id=foo"
         );
         qs_test!(
-            |request| {
-                request.pinned().limit(42)
-            },
+            |request| { request.pinned().limit(42) },
             "?pinned=1&limit=42"
         );
         qs_test!(
-            |request| {
-                request.max_id("foo").only_media()
-            },
+            |request| { request.max_id("foo").only_media() },
             "?only_media=1&max_id=foo"
         );
         qs_test!(
-            |request| {
-                request.max_id("foo").exclude_replies()
-            },
+            |request| { request.max_id("foo").exclude_replies() },
             "?exclude_replies=1&max_id=foo"
         );
         qs_test!(
-            |request| {
-                request.max_id("foo").pinned()
-            },
+            |request| { request.max_id("foo").pinned() },
             "?pinned=1&max_id=foo"
         );
         qs_test!(
-            |request| {
-                request.max_id("foo").since_id("foo")
-            },
+            |request| { request.max_id("foo").since_id("foo") },
             "?max_id=foo&since_id=foo"
         );
         qs_test!(
-            |request| {
-                request.max_id("foo").limit(42)
-            },
+            |request| { request.max_id("foo").limit(42) },
             "?max_id=foo&limit=42"
         );
         qs_test!(
-            |request| {
-                request.since_id("foo").only_media()
-            },
+            |request| { request.since_id("foo").only_media() },
             "?only_media=1&since_id=foo"
         );
         qs_test!(
-            |request| {
-                request.since_id("foo").exclude_replies()
-            },
+            |request| { request.since_id("foo").exclude_replies() },
             "?exclude_replies=1&since_id=foo"
         );
         qs_test!(
-            |request| {
-                request.since_id("foo").pinned()
-            },
+            |request| { request.since_id("foo").pinned() },
             "?pinned=1&since_id=foo"
         );
         qs_test!(
-            |request| {
-                request.since_id("foo").max_id("foo")
-            },
+            |request| { request.since_id("foo").max_id("foo") },
             "?max_id=foo&since_id=foo"
         );
         qs_test!(
-            |request| {
-                request.since_id("foo").limit(42)
-            },
+            |request| { request.since_id("foo").limit(42) },
             "?since_id=foo&limit=42"
         );
         qs_test!(
-            |request| {
-                request.limit(42).only_media()
-            },
+            |request| { request.limit(42).only_media() },
             "?only_media=1&limit=42"
         );
         qs_test!(
-            |request| {
-                request.limit(42).exclude_replies()
-            },
+            |request| { request.limit(42).exclude_replies() },
             "?exclude_replies=1&limit=42"
         );
         qs_test!(
-            |request| {
-                request.limit(42).pinned()
-            },
+            |request| { request.limit(42).pinned() },
             "?pinned=1&limit=42"
         );
         qs_test!(
-            |request| {
-                request.limit(42).max_id("foo")
-            },
+            |request| { request.limit(42).max_id("foo") },
             "?max_id=foo&limit=42"
         );
         qs_test!(
-            |request| {
-                request.limit(42).since_id("foo")
-            },
+            |request| { request.limit(42).since_id("foo") },
             "?since_id=foo&limit=42"
         );
     }

--- a/src/requests/statuses.rs
+++ b/src/requests/statuses.rs
@@ -25,8 +25,10 @@ mod bool_qs_serialize {
 /// ```
 /// # extern crate elefren;
 /// # use elefren::StatusesRequest;
-/// let mut request = StatusesRequest::new();
-/// request.only_media().pinned().since_id("foo");
+/// let request = StatusesRequest::new()
+///     .only_media()
+///     .pinned()
+///     .since_id("foo");
 /// # assert_eq!(&request.to_querystring().expect("Couldn't serialize qs")[..], "?only_media=1&pinned=1&since_id=foo");
 /// ```
 #[derive(Clone, Debug, Default, PartialEq, Serialize)]
@@ -91,7 +93,7 @@ impl<'a> StatusesRequest<'a> {
     /// # use elefren::StatusesRequest;
     /// let mut request = StatusesRequest::new();
     /// assert_eq!(&request.only_media().to_querystring().expect("Couldn't serialize qs"), "?only_media=1");
-    pub fn only_media(&mut self) -> &mut Self {
+    pub fn only_media(mut self) -> Self {
         self.only_media = true;
         self
     }
@@ -112,7 +114,7 @@ impl<'a> StatusesRequest<'a> {
     ///     "?exclude_reblogs=1"
     /// );
     /// ```
-    pub fn exclude_reblogs(&mut self) -> &mut Self {
+    pub fn exclude_reblogs(mut self) -> Self {
         self.exclude_reblogs = true;
         self
     }
@@ -133,7 +135,7 @@ impl<'a> StatusesRequest<'a> {
     ///     "?exclude_replies=1"
     /// );
     /// ```
-    pub fn exclude_replies(&mut self) -> &mut Self {
+    pub fn exclude_replies(mut self) -> Self {
         self.exclude_replies = true;
         self
     }
@@ -154,7 +156,7 @@ impl<'a> StatusesRequest<'a> {
     ///     "?pinned=1"
     /// );
     /// ```
-    pub fn pinned(&mut self) -> &mut Self {
+    pub fn pinned(mut self) -> Self {
         self.pinned = true;
         self
     }
@@ -175,7 +177,7 @@ impl<'a> StatusesRequest<'a> {
     ///     "?max_id=foo"
     /// );
     /// ```
-    pub fn max_id<S: Into<Cow<'a, str>>>(&mut self, max_id: S) -> &mut Self {
+    pub fn max_id<S: Into<Cow<'a, str>>>(mut self, max_id: S) -> Self {
         self.max_id = Some(max_id.into());
         self
     }
@@ -196,7 +198,7 @@ impl<'a> StatusesRequest<'a> {
     ///     "?since_id=foo"
     /// );
     /// ```
-    pub fn since_id<S: Into<Cow<'a, str>>>(&mut self, since_id: S) -> &mut Self {
+    pub fn since_id<S: Into<Cow<'a, str>>>(mut self, since_id: S) -> Self {
         self.since_id = Some(since_id.into());
         self
     }
@@ -217,7 +219,7 @@ impl<'a> StatusesRequest<'a> {
     ///     "?limit=10"
     /// );
     /// ```
-    pub fn limit(&mut self, limit: usize) -> &mut Self {
+    pub fn limit(mut self, limit: usize) -> Self {
         self.limit = Some(limit);
         self
     }
@@ -238,7 +240,7 @@ impl<'a> StatusesRequest<'a> {
     ///     "?min_id=foobar"
     /// );
     /// ```
-    pub fn min_id<S: Into<Cow<'a, str>>>(&mut self, min_id: S) -> &mut Self {
+    pub fn min_id<S: Into<Cow<'a, str>>>(mut self, min_id: S) -> Self {
         self.min_id = Some(min_id.into());
         self
     }
@@ -289,8 +291,7 @@ mod tests {
 
     #[test]
     fn test_only_media() {
-        let mut request = StatusesRequest::new();
-        request.only_media();
+        let request = StatusesRequest::new().only_media();
         assert_eq!(
             request,
             StatusesRequest {
@@ -308,8 +309,7 @@ mod tests {
 
     #[test]
     fn test_exclude_replies() {
-        let mut request = StatusesRequest::new();
-        request.exclude_replies();
+        let request = StatusesRequest::new().exclude_replies();
         assert_eq!(
             request,
             StatusesRequest {
@@ -326,8 +326,7 @@ mod tests {
     }
     #[test]
     fn test_pinned() {
-        let mut request = StatusesRequest::new();
-        request.pinned();
+        let request = StatusesRequest::new().pinned();
         assert_eq!(
             request,
             StatusesRequest {
@@ -344,8 +343,7 @@ mod tests {
     }
     #[test]
     fn test_max_id() {
-        let mut request = StatusesRequest::new();
-        request.max_id("foo");
+        let request = StatusesRequest::new().max_id("foo");
         assert_eq!(
             request,
             StatusesRequest {
@@ -362,8 +360,7 @@ mod tests {
     }
     #[test]
     fn test_since_id() {
-        let mut request = StatusesRequest::new();
-        request.since_id("foo");
+        let request = StatusesRequest::new().since_id("foo");
         assert_eq!(
             request,
             StatusesRequest {
@@ -380,8 +377,7 @@ mod tests {
     }
     #[test]
     fn test_limit() {
-        let mut request = StatusesRequest::new();
-        request.limit(42);
+        let request = StatusesRequest::new().limit(42);
         assert_eq!(
             request,
             StatusesRequest {
@@ -398,8 +394,7 @@ mod tests {
     }
     #[test]
     fn test_min_id() {
-        let mut request = StatusesRequest::new();
-        request.min_id("foo");
+        let request = StatusesRequest::new().min_id("foo");
         assert_eq!(
             request,
             StatusesRequest {
@@ -419,8 +414,8 @@ mod tests {
         macro_rules! qs_test {
             (|$r:ident| $b:block, $expected:expr) => {
                 {
-                    let mut $r = StatusesRequest::new();
-                    $b
+                    let $r = StatusesRequest::new();
+                    let $r = $b;
                     let qs = $r.to_querystring().expect("Failed to serialize querystring");
                     assert_eq!(&qs, $expected);
                 }
@@ -429,217 +424,217 @@ mod tests {
 
         qs_test!(
             |request| {
-                request.only_media();
+                request.only_media()
             },
             "?only_media=1"
         );
         qs_test!(
             |request| {
-                request.exclude_replies();
+                request.exclude_replies()
             },
             "?exclude_replies=1"
         );
         qs_test!(
             |request| {
-                request.pinned();
+                request.pinned()
             },
             "?pinned=1"
         );
         qs_test!(
             |request| {
-                request.max_id("foo");
+                request.max_id("foo")
             },
             "?max_id=foo"
         );
         qs_test!(
             |request| {
-                request.since_id("foo");
+                request.since_id("foo")
             },
             "?since_id=foo"
         );
         qs_test!(
             |request| {
-                request.limit(42);
+                request.limit(42)
             },
             "?limit=42"
         );
         qs_test!(
             |request| {
-                request.only_media().exclude_replies();
+                request.only_media().exclude_replies()
             },
             "?only_media=1&exclude_replies=1"
         );
         qs_test!(
             |request| {
-                request.only_media().pinned();
+                request.only_media().pinned()
             },
             "?only_media=1&pinned=1"
         );
         qs_test!(
             |request| {
-                request.only_media().max_id("foo");
+                request.only_media().max_id("foo")
             },
             "?only_media=1&max_id=foo"
         );
         qs_test!(
             |request| {
-                request.only_media().since_id("foo");
+                request.only_media().since_id("foo")
             },
             "?only_media=1&since_id=foo"
         );
         qs_test!(
             |request| {
-                request.only_media().limit(42);
+                request.only_media().limit(42)
             },
             "?only_media=1&limit=42"
         );
         qs_test!(
             |request| {
-                request.exclude_replies().only_media();
+                request.exclude_replies().only_media()
             },
             "?only_media=1&exclude_replies=1"
         );
         qs_test!(
             |request| {
-                request.exclude_replies().pinned();
+                request.exclude_replies().pinned()
             },
             "?exclude_replies=1&pinned=1"
         );
         qs_test!(
             |request| {
-                request.exclude_replies().max_id("foo");
+                request.exclude_replies().max_id("foo")
             },
             "?exclude_replies=1&max_id=foo"
         );
         qs_test!(
             |request| {
-                request.exclude_replies().since_id("foo");
+                request.exclude_replies().since_id("foo")
             },
             "?exclude_replies=1&since_id=foo"
         );
         qs_test!(
             |request| {
-                request.exclude_replies().limit(42);
+                request.exclude_replies().limit(42)
             },
             "?exclude_replies=1&limit=42"
         );
         qs_test!(
             |request| {
-                request.pinned().only_media();
+                request.pinned().only_media()
             },
             "?only_media=1&pinned=1"
         );
         qs_test!(
             |request| {
-                request.pinned().exclude_replies();
+                request.pinned().exclude_replies()
             },
             "?exclude_replies=1&pinned=1"
         );
         qs_test!(
             |request| {
-                request.pinned().max_id("foo");
+                request.pinned().max_id("foo")
             },
             "?pinned=1&max_id=foo"
         );
         qs_test!(
             |request| {
-                request.pinned().since_id("foo");
+                request.pinned().since_id("foo")
             },
             "?pinned=1&since_id=foo"
         );
         qs_test!(
             |request| {
-                request.pinned().limit(42);
+                request.pinned().limit(42)
             },
             "?pinned=1&limit=42"
         );
         qs_test!(
             |request| {
-                request.max_id("foo").only_media();
+                request.max_id("foo").only_media()
             },
             "?only_media=1&max_id=foo"
         );
         qs_test!(
             |request| {
-                request.max_id("foo").exclude_replies();
+                request.max_id("foo").exclude_replies()
             },
             "?exclude_replies=1&max_id=foo"
         );
         qs_test!(
             |request| {
-                request.max_id("foo").pinned();
+                request.max_id("foo").pinned()
             },
             "?pinned=1&max_id=foo"
         );
         qs_test!(
             |request| {
-                request.max_id("foo").since_id("foo");
+                request.max_id("foo").since_id("foo")
             },
             "?max_id=foo&since_id=foo"
         );
         qs_test!(
             |request| {
-                request.max_id("foo").limit(42);
+                request.max_id("foo").limit(42)
             },
             "?max_id=foo&limit=42"
         );
         qs_test!(
             |request| {
-                request.since_id("foo").only_media();
+                request.since_id("foo").only_media()
             },
             "?only_media=1&since_id=foo"
         );
         qs_test!(
             |request| {
-                request.since_id("foo").exclude_replies();
+                request.since_id("foo").exclude_replies()
             },
             "?exclude_replies=1&since_id=foo"
         );
         qs_test!(
             |request| {
-                request.since_id("foo").pinned();
+                request.since_id("foo").pinned()
             },
             "?pinned=1&since_id=foo"
         );
         qs_test!(
             |request| {
-                request.since_id("foo").max_id("foo");
+                request.since_id("foo").max_id("foo")
             },
             "?max_id=foo&since_id=foo"
         );
         qs_test!(
             |request| {
-                request.since_id("foo").limit(42);
+                request.since_id("foo").limit(42)
             },
             "?since_id=foo&limit=42"
         );
         qs_test!(
             |request| {
-                request.limit(42).only_media();
+                request.limit(42).only_media()
             },
             "?only_media=1&limit=42"
         );
         qs_test!(
             |request| {
-                request.limit(42).exclude_replies();
+                request.limit(42).exclude_replies()
             },
             "?exclude_replies=1&limit=42"
         );
         qs_test!(
             |request| {
-                request.limit(42).pinned();
+                request.limit(42).pinned()
             },
             "?pinned=1&limit=42"
         );
         qs_test!(
             |request| {
-                request.limit(42).max_id("foo");
+                request.limit(42).max_id("foo")
             },
             "?max_id=foo&limit=42"
         );
         qs_test!(
             |request| {
-                request.limit(42).since_id("foo");
+                request.limit(42).since_id("foo")
             },
             "?since_id=foo&limit=42"
         );

--- a/src/requests/update_credentials.rs
+++ b/src/requests/update_credentials.rs
@@ -27,11 +27,10 @@ use crate::{
 /// use elefren::{prelude::*, status_builder::Visibility, UpdateCredsRequest};
 ///
 /// let client = Mastodon::from(data);
-/// let mut builder = UpdateCredsRequest::new();
+/// let builder = UpdateCredsRequest::new()
+///     .privacy(Visibility::Unlisted);
 ///
-/// builder.privacy(Visibility::Unlisted);
-///
-/// let result = client.update_credentials(&mut builder)?;
+/// let result = client.update_credentials(builder)?;
 /// #   Ok(())
 /// # }
 /// ```
@@ -75,7 +74,7 @@ impl UpdateCredsRequest {
     ///
     /// builder.display_name("my new display name");
     /// ```
-    pub fn display_name<D: Display>(&mut self, name: D) -> &mut Self {
+    pub fn display_name<D: Display>(mut self, name: D) -> Self {
         self.display_name = Some(name.to_string());
         self
     }
@@ -92,7 +91,7 @@ impl UpdateCredsRequest {
     ///
     /// builder.note("my new note");
     /// ```
-    pub fn note<D: Display>(&mut self, note: D) -> &mut Self {
+    pub fn note<D: Display>(mut self, note: D) -> Self {
         self.note = Some(note.to_string());
         self
     }
@@ -109,7 +108,7 @@ impl UpdateCredsRequest {
     ///
     /// builder.avatar("/path/to/my/new/avatar");
     /// ```
-    pub fn avatar<P: AsRef<Path>>(&mut self, path: P) -> &mut Self {
+    pub fn avatar<P: AsRef<Path>>(mut self, path: P) -> Self {
         let path = path.as_ref();
         let path = path.to_path_buf();
         self.avatar = Some(path);
@@ -128,7 +127,7 @@ impl UpdateCredsRequest {
     ///
     /// builder.header("/path/to/my/new/header");
     /// ```
-    pub fn header<P: AsRef<Path>>(&mut self, path: P) -> &mut Self {
+    pub fn header<P: AsRef<Path>>(mut self, path: P) -> Self {
         let path = path.as_ref();
         let path = path.to_path_buf();
         self.header = Some(path);
@@ -147,7 +146,7 @@ impl UpdateCredsRequest {
     ///
     /// builder.privacy(Visibility::Public);
     /// ```
-    pub fn privacy(&mut self, privacy: status_builder::Visibility) -> &mut Self {
+    pub fn privacy(mut self, privacy: status_builder::Visibility) -> Self {
         self.privacy = Some(privacy);
         self
     }
@@ -164,7 +163,7 @@ impl UpdateCredsRequest {
     ///
     /// builder.sensitive(true);
     /// ```
-    pub fn sensitive(&mut self, sensitive: bool) -> &mut Self {
+    pub fn sensitive(mut self, sensitive: bool) -> Self {
         self.sensitive = Some(sensitive);
         self
     }
@@ -181,12 +180,12 @@ impl UpdateCredsRequest {
     ///
     /// builder.field_attribute("some key", "some value");
     /// ```
-    pub fn field_attribute(&mut self, name: &str, value: &str) -> &mut Self {
+    pub fn field_attribute(mut self, name: &str, value: &str) -> Self {
         self.field_attributes.push(MetadataField::new(name, value));
         self
     }
 
-    pub(crate) fn build(&mut self) -> Result<Credentials> {
+    pub(crate) fn build(self) -> Result<Credentials> {
         Ok(Credentials {
             display_name: self.display_name.clone(),
             note: self.note.clone(),
@@ -222,8 +221,7 @@ mod tests {
 
     #[test]
     fn test_update_creds_request_display_name() {
-        let mut builder = UpdateCredsRequest::new();
-        builder.display_name("foo");
+        let builder = UpdateCredsRequest::new().display_name("foo");
         assert_eq!(
             builder,
             UpdateCredsRequest {
@@ -235,8 +233,7 @@ mod tests {
 
     #[test]
     fn test_update_creds_request_note() {
-        let mut builder = UpdateCredsRequest::new();
-        builder.note("foo");
+        let builder = UpdateCredsRequest::new().note("foo");
         assert_eq!(
             builder,
             UpdateCredsRequest {
@@ -248,8 +245,7 @@ mod tests {
 
     #[test]
     fn test_update_creds_request_avatar() {
-        let mut builder = UpdateCredsRequest::new();
-        builder.avatar("/path/to/avatar.png");
+        let builder = UpdateCredsRequest::new().avatar("/path/to/avatar.png");
         assert_eq!(
             builder,
             UpdateCredsRequest {
@@ -261,8 +257,7 @@ mod tests {
 
     #[test]
     fn test_update_creds_request_header() {
-        let mut builder = UpdateCredsRequest::new();
-        builder.header("/path/to/header.png");
+        let builder = UpdateCredsRequest::new().header("/path/to/header.png");
         assert_eq!(
             builder,
             UpdateCredsRequest {
@@ -274,8 +269,7 @@ mod tests {
 
     #[test]
     fn test_update_creds_request_privacy() {
-        let mut builder = UpdateCredsRequest::new();
-        builder.privacy(Visibility::Public);
+        let builder = UpdateCredsRequest::new().privacy(Visibility::Public);
         assert_eq!(
             builder,
             UpdateCredsRequest {
@@ -287,8 +281,7 @@ mod tests {
 
     #[test]
     fn test_update_creds_request_sensitive() {
-        let mut builder = UpdateCredsRequest::new();
-        builder.sensitive(true);
+        let builder = UpdateCredsRequest::new().sensitive(true);
         assert_eq!(
             builder,
             UpdateCredsRequest {
@@ -300,8 +293,7 @@ mod tests {
 
     #[test]
     fn test_update_creds_request_field_attribute() {
-        let mut builder = UpdateCredsRequest::new();
-        builder.field_attribute("foo", "bar");
+        let builder = UpdateCredsRequest::new().field_attribute("foo", "bar");
         assert_eq!(
             builder,
             UpdateCredsRequest {
@@ -313,8 +305,7 @@ mod tests {
 
     #[test]
     fn test_update_creds_request_build() {
-        let mut builder = UpdateCredsRequest::new();
-        builder.display_name("test").note("a note");
+        let builder = UpdateCredsRequest::new().display_name("test").note("a note");
         let creds = builder.build().expect("Couldn't build Credentials");
         assert_eq!(
             creds,

--- a/src/requests/update_credentials.rs
+++ b/src/requests/update_credentials.rs
@@ -195,7 +195,7 @@ impl UpdateCredsRequest {
                 privacy: self.privacy,
                 sensitive: self.sensitive,
             }),
-            fields_attributes: self.field_attributes.clone(),
+            fields_attributes: self.field_attributes,
         })
     }
 }
@@ -305,7 +305,9 @@ mod tests {
 
     #[test]
     fn test_update_creds_request_build() {
-        let builder = UpdateCredsRequest::new().display_name("test").note("a note");
+        let builder = UpdateCredsRequest::new()
+            .display_name("test")
+            .note("a note");
         let creds = builder.build().expect("Couldn't build Credentials");
         assert_eq!(
             creds,


### PR DESCRIPTION
This adds a module, accessible by compiling with `--features async`,
that provides an `elefren::async::Client`. The client is
runtime-agnostic, and currently only provides unauthenticated access,
see the docs for the full list of methods that can be performed* with
this client.

\* note that some API calls are publicly available by default, but can be
changed via instance settings to not be publicly accessible

